### PR TITLE
Add current directory to python path when running test_submission

### DIFF
--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -12,6 +12,10 @@ import numpy as np
 import cloudpickle as pickle
 
 
+import sys
+sys.path.append('')
+
+
 def _delete_line_from_file(f_name, line_to_delete):
     with open(f_name, "r+") as f:
         lines = f.readlines()


### PR DESCRIPTION
This allows that local packages in the starting kit are importable

That is what we are doing for now in the https://github.com/ramp-kits/mars_craters starting kit, where there is a `workflow` directory with all the custom code we need for defining the workflow in problem.py (it is too much too put eg everything in problem.py)