### PR TITLE
Making ramp_workflow pip installable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 dist: trusty
 env:
-  - PYTHON_VERSION=2.7
-  - PYTHON_VERSION=3.5
-  - PYTHON_VERSION=3.6
+  - PYTHON_VERSION=2.7 IPYTHON_KERNEL=python2
+  - PYTHON_VERSION=3.5 IPYTHON_KERNEL=python3
+  - PYTHON_VERSION=3.6 IPYTHON_KERNEL=python3
 before_install:
     - wget -q http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
@@ -14,6 +14,7 @@ install:
     - conda create -n testenv --yes pip python=$PYTHON_VERSION
     - source activate testenv
     - pip install -r testing-requirements.txt
+    # Adding tensorflow here due to failures in Py2.7 build fails with MNIST
     - pip install tensorflow
     - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
 install:
     - conda create -n testenv --yes pip python=$PYTHON_VERSION
     - source activate testenv
-    - conda install --yes pandas scikit-learn scikit-image cloudpickle joblib gitpython
-    - conda install --yes pytest flake8 nbconvert jupyter
+    - pip install -r testing-requirements.txt
+    - pip install tensorflow
     - pip install .
 script:
     - pytest -s -v rampwf

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ install:
     - conda create -n testenv --yes pip python=$PYTHON_VERSION
     - source activate testenv
     - source install_requirements.sh
-    - pip install pytest pytest-cov codecov
-    - pip install -q flake8
+    - pip install -q pytest pytest-cov codecov
+    - pip install -q flake8 gitpython jupyter
     - pip install .
 script:
     - pytest -s -v --cov=rampwf rampwf

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,7 @@ install:
     - pip install .
 script:
     - pytest -s -v --cov=rampwf rampwf
+after_success:
+    - codecov
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
     - conda create -n testenv --yes pip python=$PYTHON_VERSION
     - source activate testenv
     - source install_requirements.sh
-    - pip install codecov
+    - pip install pytest pytest-cov codecov
     - pip install -q flake8
     - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install:
     - pip install tensorflow
     - pip install .
 script:
-    - pytest -s -v rampwf
+    - pytest -s -v --cov=rampwf rampwf
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,10 @@ before_install:
 install:
     - conda create -n testenv --yes pip python=$PYTHON_VERSION
     - source activate testenv
-    - pip install -r testing-requirements.txt
+    - conda install --yes pandas scikit-learn scikit-image cloudpickle joblib gitpython
+    - conda install --yes pytest flake8 nbconvert jupyter
     - pip install .
 script:
-    - pytest -s -v --cov=rampwf rampwf
-after_success:
-    - codecov
+    - pytest -s -v rampwf
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ before_install:
 install:
     - conda create -n testenv --yes pip python=$PYTHON_VERSION
     - source activate testenv
-    - source install_requirements.sh
-    - pip install -q pytest pytest-cov codecov
-    - pip install -q flake8 gitpython jupyter
+    - pip install -r testing-requirements.txt
     - pip install .
 script:
     - pytest -s -v --cov=rampwf rampwf

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,1 +1,0 @@
-conda install --yes --quiet numpy scikit-learn

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,3 +1,1 @@
 conda install --yes --quiet numpy scikit-learn
-conda install --yes --quiet gitpython
-conda install --yes --quiet jupyter

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,5 +1,3 @@
-conda install --yes --quiet numpy scipy matplotlib scikit-learn pandas
-conda install --yes --quiet xarray gitpython
-conda install --yes --quiet jupyter netcdf4
-pip install tensorflow
-pip install keras
+conda install --yes --quiet numpy scikit-learn
+conda install --yes --quiet gitpython
+conda install --yes --quiet jupyter

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,5 +1,5 @@
-conda install --yes --quiet numpy scipy matplotlib scikit-learn pandas 
-conda install --yes --quiet xarray pytest pytest-cov gitpython 
+conda install --yes --quiet numpy scipy matplotlib scikit-learn pandas
+conda install --yes --quiet xarray gitpython
 conda install --yes --quiet scikit-image cloudpickle jupyter netcdf4
 pip install tensorflow
 pip install keras

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,6 +1,5 @@
 conda install --yes --quiet numpy scipy matplotlib scikit-learn pandas
 conda install --yes --quiet xarray gitpython
-conda install --yes --quiet scikit-image cloudpickle jupyter netcdf4
+conda install --yes --quiet cloudpickle jupyter netcdf4
 pip install tensorflow
 pip install keras
-pip install joblib

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,5 +1,5 @@
 conda install --yes --quiet numpy scipy matplotlib scikit-learn pandas
 conda install --yes --quiet xarray gitpython
-conda install --yes --quiet cloudpickle jupyter netcdf4
+conda install --yes --quiet jupyter netcdf4
 pip install tensorflow
 pip install keras

--- a/rampwf/kits/ramp_kit.py
+++ b/rampwf/kits/ramp_kit.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import os
+import pip
 from subprocess import call
 
 from .base import get_data_home
@@ -50,6 +51,9 @@ def fetch_ramp_kit(name_kit, ramp_kits_home=None):
         name_kit, git_repo_dir))
 
     os.chdir(git_repo_dir)
+    if os.path.isfile('requirements.txt'):
+        pip.main(["install", "-r", "requirements.txt"])
+
     if os.path.isfile('download_data.py'):
         call("python download_data.py", shell=True)
 

--- a/rampwf/kits/ramp_kit.py
+++ b/rampwf/kits/ramp_kit.py
@@ -8,7 +8,8 @@ from .base import get_data_home
 
 BASE_RAMP_KIT_URL = 'https://github.com/ramp-kits/'
 
-RAMP_KITS_AVAILABLE = ('boston_housing',
+RAMP_KITS_AVAILABLE = ('MNIST',
+                       'boston_housing',
                        'iris',
                        'titanic',
                        'epidemium2_cancer_mortality',
@@ -16,7 +17,6 @@ RAMP_KITS_AVAILABLE = ('boston_housing',
                        'air_passengers',
                        'el_nino',
                        'HEP_tracking',
-                       'MNIST',
                        'mouse_cytometry',
                        )
 

--- a/rampwf/kits/ramp_kit.py
+++ b/rampwf/kits/ramp_kit.py
@@ -2,7 +2,6 @@ from os.path import join
 
 import os
 from subprocess import call
-import git
 
 from .base import get_data_home
 
@@ -35,6 +34,8 @@ def fetch_ramp_kit(name_kit, ramp_kits_home=None):
         The path were the ramp-kit has been cloned.
 
     """
+    import git
+
     if name_kit not in RAMP_KITS_AVAILABLE:
         raise ValueError("The ramp-kit '{}' requested is not available."
                          " The available kits are {}.".format(

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -9,7 +9,7 @@ import imp
 from os.path import join, abspath
 
 import numpy as np
-import cloudpickle as pickle
+# import cloudpickle as pickle
 
 
 def _delete_line_from_file(f_name, line_to_delete):

--- a/rampwf/workflows/image_classifier.py
+++ b/rampwf/workflows/image_classifier.py
@@ -2,9 +2,6 @@ from __future__ import division
 import os
 import imp
 import numpy as np
-from skimage.io import imread
-from joblib import delayed
-from joblib import Parallel
 
 
 class ImageClassifier(object):
@@ -264,6 +261,9 @@ def _chunk_iterator(X_array, folder, y_array=None, chunk_size=1024, n_jobs=8):
     vary according to examples (hence the fact that X is a list instead of
     numpy array).
     """
+    from skimage.io import imread
+    from joblib import delayed
+    from joblib import Parallel
     for i in range(0, len(X_array), chunk_size):
         X_chunk = X_array[i:i + chunk_size]
         filenames = [
@@ -302,7 +302,7 @@ def _to_categorical(y, num_classes=None):
     categorical[np.arange(n), y] = 1
     return categorical
 
-  
+
 def get_nb_minibatches(nb_samples, batch_size):
     """Compute the number of minibatches for keras.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.13
+scikit-learn>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.13
 scipy>=0.19
+pandas>=0.19.2
 scikit-learn>=0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.13
-scikit-learn>=0.19.0
+scipy>=0.19
+scikit-learn>=0.18

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ if __name__ == "__main__":
             'Operating System :: MacOS'],
         install_requires=[
             'numpy>=1.13',
-            'scikit-learn>=0.19'],
+            'scipy>=0.19',
+            'scikit-learn>=0.18'],
         platforms='any',
         packages=find_packages(),
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -34,35 +34,40 @@ if __name__ == "__main__":
     if os.path.exists('MANIFEST'):
         os.remove('MANIFEST')
 
-    setup(name=DISTNAME,
-          maintainer=MAINTAINER,
-          include_package_data=True,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          version=VERSION,
-          download_url=DOWNLOAD_URL,
-          long_description=open('README.md').read(),
-          zip_safe=False,  # the package can run out of an .egg file
-          classifiers=['Intended Audience :: Science/Research',
-                       'Intended Audience :: Developers',
-                       'License :: OSI Approved',
-                       'Programming Language :: Python',
-                       'Topic :: Software Development',
-                       'Topic :: Scientific/Engineering',
-                       'Operating System :: Microsoft :: Windows',
-                       'Operating System :: POSIX',
-                       'Operating System :: Unix',
-                       'Operating System :: MacOS'],
-          platforms='any',
-          packages=find_packages(),
-          entry_points={
-              'console_scripts': [
-                  'ramp_test_submission='
-                  'rampwf.utils.command_line:ramp_test_submission',
-                  'ramp_test_notebook='
-                  'rampwf.utils.command_line:ramp_test_notebook',
-                  'ramp_convert_notebook='
-                  'rampwf.utils.command_line:ramp_convert_notebook',
-              ]})
+    setup(
+        name=DISTNAME,
+        maintainer=MAINTAINER,
+        include_package_data=True,
+        maintainer_email=MAINTAINER_EMAIL,
+        description=DESCRIPTION,
+        license=LICENSE,
+        url=URL,
+        version=VERSION,
+        download_url=DOWNLOAD_URL,
+        long_description=open('README.md').read(),
+        zip_safe=False,  # the package can run out of an .egg file
+        classifiers=[
+            'Intended Audience :: Science/Research',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved',
+            'Programming Language :: Python',
+            'Topic :: Software Development',
+            'Topic :: Scientific/Engineering',
+            'Operating System :: Microsoft :: Windows',
+            'Operating System :: POSIX',
+            'Operating System :: Unix',
+            'Operating System :: MacOS'],
+        install_requires=[
+            'numpy>=1.13',
+            'scikit-learn>=0.19'],
+        platforms='any',
+        packages=find_packages(),
+        entry_points={
+            'console_scripts': [
+                'ramp_test_submission='
+                'rampwf.utils.command_line:ramp_test_submission',
+                'ramp_test_notebook='
+                'rampwf.utils.command_line:ramp_test_notebook',
+                'ramp_convert_notebook='
+                'rampwf.utils.command_line:ramp_convert_notebook',
+            ]})

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
         install_requires=[
             'numpy>=1.13',
             'scipy>=0.19',
+            'pandas>=0.19.2',
             'scikit-learn>=0.18'],
         platforms='any',
         packages=find_packages(),

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,0 +1,6 @@
+pytest
+pytest-cov
+codecov
+flake8
+gitpython
+jupyter

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -3,4 +3,4 @@ pytest-cov
 codecov
 flake8
 gitpython
-nbconvert
+nbconvert[execute]

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -3,4 +3,4 @@ pytest-cov
 codecov
 flake8
 gitpython
-jupyter
+nbconvert


### PR DESCRIPTION
This PR intends to clean up the dependency tree of ramp_workflow.

The idea is to trim off all dependencies related to a particular ramp-kit.

The ramp-kits will therefore need to have a specific requirement.txt file listing the dependencies, which will be installed then using pip or conda.