### PR TITLE
Pretty print CV scores

### DIFF
--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -18,7 +18,7 @@ from .combine import get_score_cv_bags
 fg_colors = {
     'official_train': 'light_green',
     'official_valid': 'light_blue',
-    'official_test': 'light_red',
+    'official_test': 'red',
     'train': 'dark_sea_green_3b',
     'valid': 'light_slate_blue',
     'test': 'pink_1',
@@ -137,7 +137,7 @@ def _print_single_score(score_type, ground_truth, predictions, step,
 
 def _score_matrix(score_types, ground_truth, predictions,
                   indent='', verbose=False):
-    """Pretty print the matrix of scores
+    """Pretty print the matrix of scores.
 
     Parameters
     ----------
@@ -187,9 +187,24 @@ def _score_matrix(score_types, ground_truth, predictions,
                                    list(df_scores.index.values)):
             if line.strip() == 'step':
                 continue
+            if color_key is None:
+                # table header
+                line = stylize(line, fg('gold_3b') + attr('bold'))
+            if color_key is not None:
+                tokens = line.split()
+                tokens_bak = tokens[:]
+                if 'official_' + color_key in fg_colors:
+                    # line label and official score bold & bright
+                    label_color = fg(fg_colors['official_' + color_key])
+                    tokens[0] = stylize(tokens[0], label_color + attr('bold'))
+                    tokens[1] = stylize(tokens[1], label_color + attr('bold'))
+                if color_key in fg_colors:
+                    # other scores pale
+                    tokens[2:] = [stylize(token, fg(fg_colors[color_key]))
+                                  for token in tokens[2:]]
+                for token_from, token_to in zip(tokens_bak, tokens):
+                    line = line.replace(token_from, token_to)
             line = indent + line
-            if color_key is not None and 'official_' + color_key in fg_colors:
-                line = stylize(line, fg(fg_colors['official_' + color_key]))
             df_repr_out.append(line)
         print('\n'.join(df_repr_out))
     return df_scores

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -175,7 +175,7 @@ def _score_matrix(score_types, ground_truth, predictions,
     if verbose:
         try:
             # try to re-order columns/rows in the printed array
-            df_scores = df_scores.loc[['train', 'test', 'valid'],
+            df_scores = df_scores.loc[['train', 'valid', 'test'],
                                       [key.name for key in score_types]]
         except Exception:
             _print_warning("Couldn't re-order the score matrix..")
@@ -185,9 +185,11 @@ def _score_matrix(score_types, ground_truth, predictions,
         for line, color_key in zip(df_repr.splitlines(),
                                    [None, None] +
                                    list(df_scores.index.values)):
+            if line.strip() == 'step':
+                continue
             line = indent + line
-            if color_key is not None and color_key in fg_colors:
-                line = stylize(line, fg(fg_colors[color_key]))
+            if color_key is not None and 'official_' + color_key in fg_colors:
+                line = stylize(line, fg(fg_colors['official_' + color_key]))
             df_repr_out.append(line)
         print('\n'.join(df_repr_out))
     return df_scores
@@ -310,14 +312,14 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
 
         _print_title('CV fold {}'.format(fold_i))
         df_scores = _score_matrix(
-                score_types,
-                ground_truth=OrderedDict([('train', ground_truth_train_train),
-                                          ('valid', ground_truth_train_valid),
-                                          ('test', ground_truth_test)]),
-                predictions=OrderedDict([('train', predictions_train_train),
-                                         ('valid', predictions_train_valid),
-                                         ('test', predictions_test)]),
-                indent='\t', verbose=True)
+            score_types,
+            ground_truth=OrderedDict([('train', ground_truth_train_train),
+                                      ('valid', ground_truth_train_valid),
+                                      ('test', ground_truth_test)]),
+            predictions=OrderedDict([('train', predictions_train_train),
+                                     ('valid', predictions_train_valid),
+                                     ('test', predictions_test)]),
+            indent='\t', verbose=True)
 
         for step, container in [('train', train_train_scoress),
                                 ('valid', train_valid_scoress),

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -174,17 +174,22 @@ def _score_matrix(score_types, ground_truth, predictions,
 
     if verbose:
         try:
-            # try to re-order columns in the printed array
-            df_scores = df_scores.loc[['train', 'test', 'valid'], :]
-        except:
-            # there were some extra steps in the dataset that
-            # we couldn't  handle
-            pass
-        df_repr = repr(df_scores)
-        if indent:
-            df_repr = '\n'.join([indent + line
-                                 for line in df_repr.splitlines()])
-        print(df_repr)
+            # try to re-order columns/rows in the printed array
+            df_scores = df_scores.loc[['train', 'test', 'valid'],
+                                      [key.name for key in score_types]]
+        except Exception:
+            _print_warning("Couldn't re-order the score matrix..")
+        with pd.option_context("display.width", 160):
+            df_repr = repr(df_scores)
+        df_repr_out = []
+        for line, color_key in zip(df_repr.splitlines(),
+                                   [None, None] +
+                                   list(df_scores.index.values)):
+            line = indent + line
+            if color_key is not None and color_key in fg_colors:
+                line = stylize(line, fg(fg_colors[color_key]))
+            df_repr_out.append(line)
+        print('\n'.join(df_repr_out))
     return df_scores
 
 


### PR DESCRIPTION
Currently, when `ramp_test_submission` is used, scores are printed on different subsets of the data for each CV fold. These are somewhat difficult to parse, particularly if the number of scores becomes large (thinking `mars_craters`).

For instance, for `california_rainfall` we will get,
```
CV fold 0
        train BSS = -1.489
        valid BSS = -2.388
        test BSS = -1.386
        train BS = 0.244
        valid BS = 0.246
        test BS = 0.242
        train BS Rel = 0.018
        valid BS Rel = 0.014
        test BS Rel = 0.023
        train BS Res = 0.073
        valid BS Res = 0.115
        test BS Res = 0.111
        train AUC = 0.712
        valid AUC = 0.806
        test AUC = 0.773
```

This PR uses pandas to pretty print a table of scores instead. The previous example would thus produce,
```
CV fold 0
        score    AUC     BS  BS Rel  BS Res    BSS
        step
        train  0.712  0.244   0.018   0.073 -1.489
        test   0.773  0.242   0.023   0.111 -1.386
        valid  0.806  0.246   0.014   0.115 -2.388
```

The only point currently not supported is `c_prefix = 'official_'` could someone explain when this is used? I haven't seen its use when running the test suite.

This only changes the score visualization for CV folds, if this PR is accepted, the "Mean CV scores" table could also be refactored to use the same approach.

Please let me know if you have any comments. Thanks.