### PR TITLE
Update import source name to allow caching multiple submissions

### DIFF
--- a/rampwf/utils/importing.py
+++ b/rampwf/utils/importing.py
@@ -1,3 +1,7 @@
+"""
+Utility to import local files from the filesystem as modules.
+
+"""
 import imp
 import os
 
@@ -18,8 +22,8 @@ def import_file(module_path, filename):
     submitted_module : module object
 
     """
-    submitted_path = ('.'
-        .join(list(os.path.split(module_path)) + [filename])
+    submitted_path = (
+        '.'.join(list(os.path.split(module_path)) + [filename])
         .replace('/', ''))
     submitted_file = os.path.join(module_path, filename + '.py')
     submitted_module = imp.load_source(submitted_path, submitted_file)

--- a/rampwf/utils/importing.py
+++ b/rampwf/utils/importing.py
@@ -1,0 +1,26 @@
+import imp
+import os
+
+
+def import_file(module_path, filename):
+    """
+    Import a submission file based on the filename and submission path.abs
+
+    Parameters
+    ----------
+    module_path : str
+        The path to the submission directory
+    filename : str
+        The filename of the submitted workflow element.
+
+    Returns
+    -------
+    submitted_module : module object
+
+    """
+    submitted_path = ('.'
+        .join(list(os.path.split(module_path)) + [filename])
+        .replace('/', ''))
+    submitted_file = '{}/{}.py'.format(module_path, filename)
+    submitted_module = imp.load_source(submitted_path, submitted_file)
+    return submitted_module

--- a/rampwf/utils/importing.py
+++ b/rampwf/utils/importing.py
@@ -9,7 +9,7 @@ def import_file(module_path, filename):
     Parameters
     ----------
     module_path : str
-        The path to the submission directory
+        The path to the submission directory.
     filename : str
         The filename of the submitted workflow element.
 
@@ -21,6 +21,6 @@ def import_file(module_path, filename):
     submitted_path = ('.'
         .join(list(os.path.split(module_path)) + [filename])
         .replace('/', ''))
-    submitted_file = '{}/{}.py'.format(module_path, filename)
+    submitted_file = os.path.join(module_path, filename + '.py')
     submitted_module = imp.load_source(submitted_path, submitted_file)
     return submitted_module

--- a/rampwf/workflows/classifier.py
+++ b/rampwf/workflows/classifier.py
@@ -1,4 +1,4 @@
-import imp
+from ..utils.importing import import_file
 
 
 class Classifier(object):
@@ -9,10 +9,7 @@ class Classifier(object):
     def train_submission(self, module_path, X_array, y_array, train_is=None):
         if train_is is None:
             train_is = slice(None, None, None)
-        submitted_classifier_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        classifier = imp.load_source(
-            self.element_names[0], submitted_classifier_file)
+        classifier = import_file(module_path, self.element_names[0])
         clf = classifier.Classifier()
         clf.fit(X_array[train_is], y_array[train_is])
         return clf

--- a/rampwf/workflows/clusterer.py
+++ b/rampwf/workflows/clusterer.py
@@ -22,8 +22,9 @@ into `prediction_types.Clustering` and evaluated by
 # Author: Balazs Kegl <balazs.kegl@gmail.com>
 # License: BSD 3 clause
 
-import imp
 import numpy as np
+
+from ..utils.importing import import_file
 
 
 class Clusterer(object):
@@ -33,10 +34,7 @@ class Clusterer(object):
     def train_submission(self, module_path, X_array, y_array, train_is=None):
         if train_is is None:
             train_is = slice(None, None, None)
-        submitted_clusterer_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        clusterer = imp.load_source(
-            self.element_names[0], submitted_clusterer_file)
+        clusterer = import_file(module_path, self.element_names[0])
         ctr = clusterer.Clusterer()
         ctr.fit(X_array[train_is], y_array[train_is])
         return ctr

--- a/rampwf/workflows/feature_extractor.py
+++ b/rampwf/workflows/feature_extractor.py
@@ -1,4 +1,4 @@
-import imp
+from ..utils.importing import import_file
 
 
 class FeatureExtractor(object):
@@ -8,10 +8,7 @@ class FeatureExtractor(object):
     def train_submission(self, module_path, X_df, y_array, train_is=None):
         if train_is is None:
             train_is = slice(None, None, None)
-        submitted_feature_extractor_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        feature_extractor = imp.load_source(
-            self.element_names[0], submitted_feature_extractor_file)
+        feature_extractor = import_file(module_path, self.element_names[0])
         fe = feature_extractor.FeatureExtractor()
         fe.fit(X_df.iloc[train_is], y_array[train_is])
         return fe

--- a/rampwf/workflows/grid_feature_extractor.py
+++ b/rampwf/workflows/grid_feature_extractor.py
@@ -8,8 +8,10 @@ y_array can be a set of binary labels or a regressor value. The values in
 y_array are assumed to be paired exactly with the values in the first
 dimension of X_ds.
 """
-import imp
+
 import pandas as pd
+
+from ..utils.importing import import_file
 
 
 class GridFeatureExtractor(object):
@@ -19,10 +21,7 @@ class GridFeatureExtractor(object):
     def train_submission(self, module_path, X_ds, y_array, train_is=None):
         if train_is is None:
             train_is = slice(None, None, None)
-        submitted_feature_extractor_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        feature_extractor = imp.load_source(
-            self.element_names[0], submitted_feature_extractor_file)
+        feature_extractor = import_file(module_path, self.element_names[0])
         fe = feature_extractor.FeatureExtractor()
         dim_set = pd.Series(list(X_ds.dims.keys()))
         time_dim = dim_set[dim_set.str.contains("time")][0]

--- a/rampwf/workflows/image_classifier.py
+++ b/rampwf/workflows/image_classifier.py
@@ -1,7 +1,10 @@
 from __future__ import division
+
 import os
-import imp
+
 import numpy as np
+
+from ..utils.importing import import_file
 
 
 class ImageClassifier(object):
@@ -73,18 +76,12 @@ class ImageClassifier(object):
         folder, X_array = folder_X_array
         if train_is is None:
             train_is = slice(None, None, None)
-        submitted_image_preprocessor_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        image_preprocessor = imp.load_source(
-            self.element_names[0], submitted_image_preprocessor_file)
+        image_preprocessor = import_file(module_path, self.element_names[0])
         transform_img = image_preprocessor.transform
         transform_test_img = getattr(image_preprocessor,
                                      'transform_test',
                                      transform_img)
-        submitted_batch_classifier_file = '{}/{}.py'.format(
-            module_path, self.element_names[1])
-        batch_classifier = imp.load_source(
-            self.element_names[1], submitted_batch_classifier_file)
+        batch_classifier = import_file(module_path, self.element_names[1])
         clf = batch_classifier.BatchClassifier()
 
         gen_builder = BatchGeneratorBuilder(

--- a/rampwf/workflows/object_detector.py
+++ b/rampwf/workflows/object_detector.py
@@ -1,7 +1,8 @@
 from __future__ import division
 
-import imp
 import numpy as np
+
+from ..utils.importing import import_file
 
 
 class ObjectDetector(object):
@@ -60,10 +61,7 @@ class ObjectDetector(object):
             train_is = slice(None, None, None)
 
         # object detector model
-        submitted_model_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        detector = imp.load_source(
-            self.element_names[0], submitted_model_file)
+        detector = import_file(module_path, self.element_names[0])
         clf = detector.ObjectDetector()
 
         # train and return fitted model

--- a/rampwf/workflows/regressor.py
+++ b/rampwf/workflows/regressor.py
@@ -1,4 +1,4 @@
-import imp
+from ..utils.importing import import_file
 
 
 class Regressor(object):
@@ -9,10 +9,7 @@ class Regressor(object):
     def train_submission(self, module_path, X_array, y_array, train_is=None):
         if train_is is None:
             train_is = slice(None, None, None)
-        submitted_regressor_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        regressor = imp.load_source(
-            self.element_names[0], submitted_regressor_file)
+        regressor = import_file(module_path, self.element_names[0])
         reg = regressor.Regressor()
         reg.fit(X_array[train_is], y_array[train_is])
         return reg

--- a/rampwf/workflows/simplified_image_classifier.py
+++ b/rampwf/workflows/simplified_image_classifier.py
@@ -1,7 +1,10 @@
 from __future__ import division
+
 import os
-import imp
+
 import numpy as np
+
+from ..utils.importing import import_file
 
 
 class SimplifiedImageClassifier(object):
@@ -51,10 +54,7 @@ class SimplifiedImageClassifier(object):
         folder, X_array = folder_X_array
         if train_is is None:
             train_is = slice(None, None, None)
-        submitted_image_classifier_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        image_classifier = imp.load_source(
-            self.element_names[0], submitted_image_classifier_file)
+        image_classifier = import_file(module_path, self.element_names[0])
         clf = image_classifier.ImageClassifier()
         img_loader = ImageLoader(
             X_array[train_is], y_array[train_is],

--- a/rampwf/workflows/ts_feature_extractor.py
+++ b/rampwf/workflows/ts_feature_extractor.py
@@ -30,8 +30,10 @@ bigger than the corresponding `check_index`.
 
 # Author: Balazs Kegl <balazs.kegl@gmail.com>
 # License: BSD 3 clause
-import imp
+
 import numpy as np
+
+from ..utils.importing import import_file
 
 
 class TimeSeriesFeatureExtractor(object):
@@ -56,10 +58,7 @@ class TimeSeriesFeatureExtractor(object):
             # is computed below
             train_is = np.arange(len(y_array))
         n_burn_in = X_ds.n_burn_in
-        submitted_ts_feature_extractor_file = '{}/{}.py'.format(
-            module_path, self.element_names[0])
-        ts_feature_extractor = imp.load_source(
-            self.element_names[0], submitted_ts_feature_extractor_file)
+        ts_feature_extractor = import_file(module_path, self.element_names[0])
         ts_fe = ts_feature_extractor.FeatureExtractor()
         # Fit is not required in the submissions but we add it here in case
         # of, e.g., a recurrent neural net which is impossible to train once


### PR DESCRIPTION
And at the same time made it into a utility function to avoid repeated code.

This allows to do a `feature_extractor.py` with something like:

```
from joblib import Memory
memory = Memory(cachedir='./cache', verbose=1)


class FeatureExtractor():
    def __init__(self):
        pass

    def fit(self, X_df, y):
        pass

    def transform(self, X_df):
        return _transform(X_df)


@memory.cache
def _transform(X_df):
    ...
    computationaly expensive feature extraction
    ...
    return X_df_transformed
```

The above already works, but then if you have multiple submissions with a different transform method (but same name), they would each time overwrite each other cached results. This patch solves that, and is in general also a good clean-up IMO.