### PR TITLE
BUG: blending detection predictions with zero confidence

### DIFF
--- a/rampwf/prediction_types/detection.py
+++ b/rampwf/prediction_types/detection.py
@@ -195,13 +195,20 @@ def combine_predictions(preds_list, iou_threshold, greedy=False):
 
         preds = np.array(preds)
 
-        # (x, y, r) are averaged weighted with the confidence
-        pred_combined = np.average(preds[:, 1:], weights=preds[:, 0], axis=0)
+        # combine in a single (c, x, y, r)
+        if preds[:, 0].sum() == 0:
+            # corner case of all confidence being zero: just taking mean
+            # because weighted average will fail
+            pred_combined = np.mean(preds, axis=0)
+        else:
+            # (x, y, r) are averaged weighted with the confidence
+            pred_combined = np.average(preds[:, 1:], weights=preds[:, 0],
+                                       axis=0)
 
-        # the confidence is averaged taking into account missing
-        # predictions
-        conf = preds[:, 0].sum() / n_preds
-        pred_combined = np.insert(pred_combined, 0, conf)
+            # the confidence is averaged taking into account missing
+            # predictions
+            conf = preds[:, 0].sum() / n_preds
+            pred_combined = np.insert(pred_combined, 0, conf)
 
         preds_combined.append(pred_combined)
 

--- a/rampwf/prediction_types/tests/test_detection_predictions.py
+++ b/rampwf/prediction_types/tests/test_detection_predictions.py
@@ -53,3 +53,16 @@ def test_combine_ignore_none():
     expected[:] = [[(2. / 3, 1, 1, 1)], [(1, 3, 3, 1)]]
     assert_allclose(expected[0], y_pred_combined[0])
     assert_allclose(expected[1], y_pred_combined[1])
+
+
+def test_combine_zero_conf():
+
+    pred1 = Predictions(
+        y_pred=[[(0, 1, 1, 1)], [(0, 1, 1, 1)]])
+    pred2 = Predictions(
+        y_pred=[[(1, 1.1, 1.1, 1)], [(0, 1, 1, 1)]])
+
+    y_pred_combined = Predictions.combine([pred1, pred2]).y_pred
+
+    expected = [[(0.5, 1.1, 1.1, 1)], [(0., 1, 1, 1)]]
+    [assert_array_equal(x, y) for x, y in zip(y_pred_combined, expected)]


### PR DESCRIPTION
Ugly hack, but I think should solve the problem. 
Ideally predictions with zero confidence are discarded in an earlier step, but I think  it is rather costly the go through all predictions just to do that.
