### PR TITLE
Suppress Runtime Warnings when importing from starting kits

### DIFF
--- a/rampwf/utils/importing.py
+++ b/rampwf/utils/importing.py
@@ -4,6 +4,7 @@ Utility to import local files from the filesystem as modules.
 """
 import imp
 import os
+import warnings
 
 
 def import_file(module_path, filename):
@@ -26,5 +27,7 @@ def import_file(module_path, filename):
         '.'.join(list(os.path.split(module_path)) + [filename])
         .replace('/', ''))
     submitted_file = os.path.join(module_path, filename + '.py')
-    submitted_module = imp.load_source(submitted_path, submitted_file)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        submitted_module = imp.load_source(submitted_path, submitted_file)
     return submitted_module


### PR DESCRIPTION
Runtime warnings have appeared recently when running the `ramp_test_submission` looking like
```bash
./submissions/starting_kit/feature_extractor.py:2: RuntimeWarning: Parent module '.submissions.starting_kit' not found while handling absolute import
  import numpy as np
```
This is quite annoying to find these warnings in the prompt so I just filtered them in this PR.
We might need to find out why these warnings have appeared..