### PR TITLE
Avoid redundant loading of training data

### DIFF
--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -532,9 +532,14 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
         the name of the submission to be tested
     """
     problem = assert_read_problem(ramp_kit_dir)
-    assert_title(ramp_kit_dir)
+
+    _print_title('Testing {}'.format(problem.problem_title))
+
     X_train, y_train, X_test, y_test = assert_data(ramp_kit_dir, ramp_data_dir)
-    cv = assert_cv(ramp_kit_dir, ramp_data_dir)
+
+    _print_title('Reading cv ...')
+    cv = list(problem.get_cv(X_train, y_train))
+
     score_types = assert_score_types(ramp_kit_dir)
 
     module_path = join(ramp_kit_dir, 'submissions', submission)


### PR DESCRIPTION
In the `testing.py` file, the `assert_*` methods tend to perform redundant tasks.

In particular, calling all other assert methods within `assert_submission` does load the `problem.py` multiple times and loads the training data twice (once through `assert_data` and once through `assert_cv`). 

This PR aims at clarifying those calls.
The first commit solves the double loading in `assert_submission` but does not touch any other method.

Should we **keep** these assert methods or simply **remove them and inline their content** in `assert_submission` ? @jorisvandenbossche @glemaitre @kegl 