### PR TITLE
lazy import tabulate

### DIFF
--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 import os
 import numpy as np
 import pandas as pd
-from ..externals.tabulate import tabulate
 
 from .testing import (
     assert_submission, assert_notebook, convert_notebook, blend_submissions)
@@ -334,7 +333,11 @@ def ramp_leaderboard():
     except ValueError as ex:
         print(ex)
         sys.exit(1)
-    print(tabulate(df, headers='keys', tablefmt='grid'))
+    try:
+        from ..externals.tabulate import tabulate
+        print(tabulate(df, headers='keys', tablefmt='grid'))
+    except:
+        print(df)
 
 
 def _filter_and_sort_leaderboard_df(

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -336,7 +336,7 @@ def ramp_leaderboard():
     try:
         from ..externals.tabulate import tabulate
         print(tabulate(df, headers='keys', tablefmt='grid'))
-    except:
+    except ImportError as ex:
         print(df)
 
 


### PR DESCRIPTION
The fancy new local `ramp_leaderboard` uses tabulate that doesn't work on windows. We'll catch the exception and revert to pandas rendering the table.