### PR TITLE
saving state and error, not only y_pred

### DIFF
--- a/rampwf/tests/test_kits.py
+++ b/rampwf/tests/test_kits.py
@@ -54,7 +54,7 @@ def test_submission(path_kit):
                 ramp_kit_dir=path_kit,
                 ramp_data_dir=path_kit,
                 submission=os.path.basename(sub), is_pickle=True,
-                save_y_preds=False, retrain=True)
+                save_output=False, retrain=True)
 
 
 def test_blending():
@@ -62,13 +62,14 @@ def test_blending():
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
         ramp_data_dir=os.path.join(PATH, "kits", "iris"),
         submission='starting_kit', is_pickle=True,
-        save_y_preds=True, retrain=True)
+        save_output=True, retrain=True)
     assert_submission(
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
         ramp_data_dir=os.path.join(PATH, "kits", "iris"),
         submission='random_forest_10_10', is_pickle=True,
-        save_y_preds=True, retrain=True)
+        save_output=True, retrain=True)
     blend_submissions(
         ['starting_kit', 'random_forest_10_10'],
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
-        ramp_data_dir=os.path.join(PATH, "kits", "iris"))
+        ramp_data_dir=os.path.join(PATH, "kits", "iris"),
+        save_output=True)

--- a/rampwf/tests/test_kits.py
+++ b/rampwf/tests/test_kits.py
@@ -75,4 +75,5 @@ def test_blending():
         ['starting_kit', 'random_forest_10_10'],
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
         ramp_data_dir=os.path.join(PATH, "kits", "iris"),
+        ramp_submission_dir=os.path.join(PATH, "kits", "iris", "submissions"),
         save_output=True)

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -144,6 +144,11 @@ def create_ramp_blend_submissions_parser():
                         type=str,
                         help='Directory containing the data. This directory'
                         ' should contain a "data" folder.')
+    parser.add_argument('--ramp_submission_dir',
+                        default='submissions',
+                        type=str,
+                        help='Directory where the submissions are stored. It '
+                        'should contain a "submissions" directory.')
     parser.add_argument('--submissions',
                         default='ALL',
                         type=str,
@@ -181,6 +186,7 @@ def ramp_blend_submissions():
 
     blend_submissions(ramp_kit_dir=args.ramp_kit_dir,
                       ramp_data_dir=args.ramp_data_dir,
+                      ramp_submission_dir=args.ramp_submission_dir,
                       submissions=submissions,
                       save_output=save_output,
                       min_improvement=float(args.min_improvement))

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -54,6 +54,11 @@ def create_ramp_test_submission_parser():
                         action='store_true',
                         help='Specify this flag to save predictions, scores, '
                              'eventual error trace, and state after training.')
+    parser.add_argument('--save-y-preds', dest='save_output',
+                        action='store_true',
+                        help='Specify this flag to save predictions, scores, '
+                             'eventual error trace, and state after training. '
+                             'Deprecated.')
     parser.add_argument('--retrain', dest='retrain',
                         action='store_true',
                         help='Specify this flag to retrain the submission '

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -32,6 +32,11 @@ def create_ramp_test_submission_parser():
                         type=str,
                         help='Directory containing the data. This directory'
                         ' should contain a "data" folder.')
+    parser.add_argument('--submission_dir',
+                        default='.',
+                        type=str,
+                        help='Directory containing the submission. This'
+                        ' directory should contain a "submissions" folder.')
     parser.add_argument('--submission',
                         default='starting_kit',
                         type=str,
@@ -87,6 +92,7 @@ def ramp_test_submission():
     for sub in submission:
         assert_submission(ramp_kit_dir=args.ramp_kit_dir,
                           ramp_data_dir=args.ramp_data_dir,
+                          submission_dir=args.submission_dir,
                           submission=sub,
                           is_pickle=is_pickle,
                           save_output=save_output,

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -45,10 +45,10 @@ def create_ramp_test_submission_parser():
     parser.add_argument('--pickle', dest='pickle', action='store_true',
                         help='Specify this flag to pickle the submission '
                              'after training.')
-    parser.add_argument('--save-y-preds', dest='save_y_preds',
+    parser.add_argument('--save-output', dest='save_output',
                         action='store_true',
-                        help='Specify this flag to save predictions '
-                             'after training.')
+                        help='Specify this flag to save predictions, scores, '
+                             'eventual error trace, and state after training.')
     parser.add_argument('--retrain', dest='retrain',
                         action='store_true',
                         help='Specify this flag to retrain the submission '
@@ -68,9 +68,9 @@ def ramp_test_submission():
     if args.pickle:
         is_pickle = True
 
-    save_y_preds = False
-    if args.save_y_preds:
-        save_y_preds = True
+    save_output = False
+    if args.save_output:
+        save_output = True
 
     retrain = False
     if args.retrain:
@@ -89,7 +89,7 @@ def ramp_test_submission():
                           ramp_data_dir=args.ramp_data_dir,
                           submission=sub,
                           is_pickle=is_pickle,
-                          save_y_preds=save_y_preds,
+                          save_output=save_output,
                           retrain=retrain)
 
 
@@ -141,10 +141,10 @@ def create_ramp_blend_submissions_parser():
                         ' Specify submissions separated by a comma without'
                         ' spaces. If "ALL", all submissions in the directory'
                         ' will be blended.')
-    parser.add_argument('--save-y-preds', dest='save_y_preds',
+    parser.add_argument('--save_output', dest='save_output',
                         action='store_true',
                         help='Specify this flag to save predictions '
-                             'after training.')
+                             'after blending.')
     parser.add_argument('--min-improvement', dest='min_improvement',
                         default='0.0',
                         help='The minimum score improvement when adding.'
@@ -156,9 +156,9 @@ def ramp_blend_submissions():
     parser = create_ramp_blend_submissions_parser()
     args = parser.parse_args()
 
-    save_y_preds = False
-    if args.save_y_preds:
-        save_y_preds = True
+    save_output = False
+    if args.save_output:
+        save_output = True
 
     if args.submissions == "ALL":
         ramp_submission_dir = join(args.ramp_kit_dir, 'submissions')
@@ -171,7 +171,7 @@ def ramp_blend_submissions():
     blend_submissions(ramp_kit_dir=args.ramp_kit_dir,
                       ramp_data_dir=args.ramp_data_dir,
                       submissions=submissions,
-                      save_y_preds=save_y_preds,
+                      save_output=save_output,
                       min_improvement=float(args.min_improvement))
 
 
@@ -254,8 +254,8 @@ def create_ramp_leaderboard_parser():
 
 def ramp_leaderboard():
     """
-    RAMP leaderboard, a simple command line to display
-    the leaderboard.
+    RAMP leaderboard, a simple command line to display the leaderboard.
+
     IMPORTANT: order to display correctly the leaderboard
     you need to save your predictions, e.g.,
     using `ramp_test_submission --submission <name> --save-y-preds`
@@ -344,8 +344,9 @@ def _filter_and_sort_leaderboard_df(
         df, cols=None, metric=None,
         sort_by=None, asc=False):
     """
-    filters and sorts rows of df where df is a DataFrame obtained
-    using _build_leaderboard_df.
+    Filter and sorts rows of df.
+
+    df is a DataFrame obtained using _build_leaderboard_df.
 
     Parameters
     ----------
@@ -436,7 +437,9 @@ def _filter_and_sort_leaderboard_df(
 
 def _build_leaderboard_df(scores_dict, precision=2):
     """
-    Get a pd.DataFrame where each row is a submission and each column
+    Get a pd.DataFrame representing the leaderboard.
+
+    Each row is a submission and each column
     is the mean or std of score on train or valid or test data for a metric.
     There is a column name 'submission' for the submission names.
     The rest of column names are prefixed by the 'train' or 'valid' or 'test'
@@ -505,7 +508,7 @@ def _build_leaderboard_df(scores_dict, precision=2):
 
 def _get_metrics(leaderboard_df):
     """
-    Get the list of metrics used in `leaderboard_df`
+    Get the list of metrics used in `leaderboard_df`.
 
     Parameters
     ----------
@@ -531,7 +534,9 @@ def _get_metrics(leaderboard_df):
 
 def _build_scores_dict(ramp_kit_dir='.'):
     """
-    Build a nested dictionary of scores using the training_output/ folder
+    Build a nested dictionary of scores.
+
+    Using the training_output/ folder
     of each submission.
 
     The structure of the folder `ramp_kit_dir` should be

--- a/rampwf/utils/io.py
+++ b/rampwf/utils/io.py
@@ -83,10 +83,10 @@ def load_y_pred(problem, data_path='.', input_path='.', suffix='test'):
         return np.load(y_pred_f_name)['y_pred']
 
 
-def set_state(state, save_y_preds, output_path):
+def set_state(state, save_output, output_path):
     """Save the submission state (per fold) in <output_path>/state.txt.
 
-    In case save_y_preds is True. Otherwise do nothing.
+    In case save_output is True. Otherwise do nothing.
 
     Parameters
     ----------
@@ -94,24 +94,24 @@ def set_state(state, save_y_preds, output_path):
         The string representing the state. Possible values are 'new',
         'trained', 'validated', 'tested', 'scored', 'training_error',
         'validating_error', 'testing_error'.
-    save_y_preds : boolean
+    save_output : boolean
         True if state should be written in file
     output_path : str
         the path into which 'state.txt' will be saved
     """
-    if save_y_preds:
+    if save_output:
         with open(os.path.join(output_path, 'state.txt'), 'w') as fd:
             fd.write(state)
 
 
-def print_submission_exception(save_y_preds, output_path):
+def print_submission_exception(save_output, output_path):
     """Print the exception trace corresponding the user submission.
 
-    In case save_y_preds is True, also save it into <output_path>/error.txt
+    In case save_output is True, also save it into <output_path>/error.txt
 
     Parameters
     ----------
-    save_y_preds : boolean
+    save_output : boolean
         True if error should be written in file
     output_path : str
         the path into which 'error.txt' will be saved
@@ -125,7 +125,7 @@ def print_submission_exception(save_y_preds, output_path):
         trace = trace[5:]
     else:
         trace = trace[4:]
-    if save_y_preds:
+    if save_output:
         with open(os.path.join(output_path, 'error.txt'), 'w') as fd:
             for s in trace:
                 fd.write(s)

--- a/rampwf/utils/io.py
+++ b/rampwf/utils/io.py
@@ -3,7 +3,8 @@
 Utilities for saving and loading predictions
 """
 import os
-
+import sys
+import traceback as tb
 import numpy as np
 
 from .pretty_print import print_warning
@@ -80,3 +81,52 @@ def load_y_pred(problem, data_path='.', input_path='.', suffix='test'):
         y_pred_f_name = os.path.join(input_path,
                                      'y_pred_{}.npz'.format(suffix))
         return np.load(y_pred_f_name)['y_pred']
+
+
+def set_state(state, save_y_preds, output_path):
+    """Save the submission state (per fold) in <output_path>/state.txt.
+
+    In case save_y_preds is True. Otherwise do nothing.
+
+    Parameters
+    ----------
+    state : str
+        The string representing the state. Possible values are 'new',
+        'trained', 'validated', 'tested', 'scored', 'training_error',
+        'validating_error', 'testing_error'.
+    save_y_preds : boolean
+        True if state should be written in file
+    output_path : str
+        the path into which 'state.txt' will be saved
+    """
+    if save_y_preds:
+        with open(os.path.join(output_path, 'state.txt'), 'w') as fd:
+            fd.write(state)
+
+
+
+def print_submission_exception(save_y_preds, output_path):
+    """Print the exception trace corresponding the user submission.
+
+    In case save_y_preds is True, also save it into <output_path>/error.txt
+
+    Parameters
+    ----------
+    save_y_preds : boolean
+        True if error should be written in file
+    output_path : str
+        the path into which 'error.txt' will be saved
+    """
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    # print the stack corresponding to user submission
+    trace = tb.format_exception(exc_type, exc_value, exc_traceback)
+    if trace[4].find('load_source') > -1:
+        trace = trace[5:]
+    else:
+        trace = trace[4:]
+    for s in trace:
+        print(s)
+    if save_y_preds:
+        with open(os.path.join(output_path, 'error.txt'), 'w') as fd:
+            for s in trace:
+                fd.write(s)

--- a/rampwf/utils/io.py
+++ b/rampwf/utils/io.py
@@ -104,7 +104,6 @@ def set_state(state, save_y_preds, output_path):
             fd.write(state)
 
 
-
 def print_submission_exception(save_y_preds, output_path):
     """Print the exception trace corresponding the user submission.
 

--- a/rampwf/utils/io.py
+++ b/rampwf/utils/io.py
@@ -120,12 +120,12 @@ def print_submission_exception(save_y_preds, output_path):
     exc_type, exc_value, exc_traceback = sys.exc_info()
     # print the stack corresponding to user submission
     trace = tb.format_exception(exc_type, exc_value, exc_traceback)
+    for s in trace:
+        print(s)
     if trace[4].find('load_source') > -1:
         trace = trace[5:]
     else:
         trace = trace[4:]
-    for s in trace:
-        print(s)
     if save_y_preds:
         with open(os.path.join(output_path, 'error.txt'), 'w') as fd:
             for s in trace:

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -151,7 +151,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
         problem, cv, y_train, y_test, predictions_valid_list,
         predictions_test_list, training_output_path,
         ramp_data_dir=ramp_data_dir, score_type_index=None,
-        save_y_preds=save_output)
+        save_output=save_output)
 
 
 def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -62,7 +62,7 @@ def assert_score_types(ramp_kit_dir='.'):
 
 def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
                       submission='starting_kit', is_pickle=False,
-                      save_y_preds=False, retrain=False):
+                      save_output=False, retrain=False):
     """Helper to test a submission from a ramp-kit.
 
     Parameters
@@ -86,7 +86,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     print_title('Training {} ...'.format(module_path))
 
     training_output_path = ''
-    if is_pickle or save_y_preds:
+    if is_pickle or save_output:
         # creating submissions/<submission>/training_output dir
         training_output_path = os.path.join(module_path, 'training_output')
         if not os.path.exists(training_output_path):
@@ -99,23 +99,23 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
 
     for fold_i, fold in enumerate(cv):
         fold_output_path = ''
-        if is_pickle or save_y_preds:
+        if is_pickle or save_output:
             # creating submissions/<submission>/training_output/fold_<i> dir
             fold_output_path = os.path.join(
                 training_output_path, 'fold_{}'.format(fold_i))
             if not os.path.exists(fold_output_path):
                 os.mkdir(fold_output_path)
-            if save_y_preds:
+            if save_output:
                 print(fold_output_path)
-                set_state('new', save_y_preds, fold_output_path)
+                set_state('new', save_output, fold_output_path)
         print_title('CV fold {}'.format(fold_i))
 
         predictions_valid, predictions_test, df_scores =\
             run_submission_on_cv_fold(
                 problem, module_path, X_train, y_train, X_test, y_test,
-                score_types, is_pickle, save_y_preds, fold_output_path,
+                score_types, is_pickle, save_output, fold_output_path,
                 fold, ramp_data_dir)
-        if save_y_preds:
+        if save_output:
             filename = os.path.join(fold_output_path, 'scores.csv')
             df_scores.to_csv(filename)
         df_scores_rounded = round_df_scores(df_scores, score_types)
@@ -139,17 +139,17 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
         print_title('----------------------------')
         run_submission_on_full_train(
             problem, module_path, X_train, y_train, X_test, y_test,
-            score_types, is_pickle, save_y_preds, training_output_path,
+            score_types, is_pickle, save_output, training_output_path,
             ramp_data_dir)
     bag_submissions(
         problem, cv, y_train, y_test, predictions_valid_list,
         predictions_test_list, training_output_path,
         ramp_data_dir=ramp_data_dir, score_type_index=0,
-        save_y_preds=save_y_preds)
+        save_output=save_output)
 
 
 def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',
-                      save_y_preds=False, min_improvement=0.0):
+                      save_output=False, min_improvement=0.0):
     problem = assert_read_problem(ramp_kit_dir)
     print_title('Blending {}'.format(problem.problem_title))
     X_train, y_train, X_test, y_test = assert_data(ramp_kit_dir, ramp_data_dir)
@@ -217,13 +217,13 @@ def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',
         problem, cv, y_train, y_test, combined_predictions_valid_list,
         combined_predictions_test_list, training_output_path,
         ramp_data_dir=ramp_data_dir, score_type_index=0,
-        save_y_preds=save_y_preds, score_table_title='Combined bagged scores',
+        save_output=save_output, score_table_title='Combined bagged scores',
         score_f_name_prefix='foldwise_best')
     # bagging the foldwise best submissions
     bag_submissions(
         problem, cv, y_train, y_test, foldwise_best_predictions_valid_list,
         foldwise_best_predictions_test_list, training_output_path,
         ramp_data_dir=ramp_data_dir, score_type_index=0,
-        save_y_preds=save_y_preds,
+        save_output=save_output,
         score_table_title='Foldwise best bagged scores',
         score_f_name_prefix='combined')

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -106,7 +106,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
             if not os.path.exists(fold_output_path):
                 os.mkdir(fold_output_path)
             if save_output:
-                set_state('new', save_output, fold_output_path)
+                set_state('training', save_output, fold_output_path)
         print_title('CV fold {}'.format(fold_i))
 
         predictions_valid, predictions_test, df_scores =\

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -61,7 +61,7 @@ def assert_score_types(ramp_kit_dir='.'):
 
 
 def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
-                      submission_dir = '.', submission='starting_kit',
+                      submission_dir='.', submission='starting_kit',
                       is_pickle=False, save_output=False, retrain=False):
     """Helper to test a submission from a ramp-kit.
 
@@ -148,7 +148,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
 
 
 def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',
-                      submission_dir = '.', save_output=False,
+                      submission_dir='.', save_output=False,
                       min_improvement=0.0):
     problem = assert_read_problem(ramp_kit_dir)
     print_title('Blending {}'.format(problem.problem_title))

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -61,8 +61,8 @@ def assert_score_types(ramp_kit_dir='.'):
 
 
 def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
-                      submission='starting_kit', is_pickle=False,
-                      save_output=False, retrain=False):
+                      submission_dir = '.', submission='starting_kit',
+                      is_pickle=False, save_output=False, retrain=False):
     """Helper to test a submission from a ramp-kit.
 
     Parameters
@@ -82,7 +82,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     cv = assert_cv(ramp_kit_dir, ramp_data_dir)
     score_types = assert_score_types(ramp_kit_dir)
 
-    module_path = os.path.join(ramp_kit_dir, 'submissions', submission)
+    module_path = os.path.join(submission_dir, 'submissions', submission)
     print_title('Training {} ...'.format(module_path))
 
     training_output_path = ''
@@ -106,7 +106,6 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
             if not os.path.exists(fold_output_path):
                 os.mkdir(fold_output_path)
             if save_output:
-                print(fold_output_path)
                 set_state('new', save_output, fold_output_path)
         print_title('CV fold {}'.format(fold_i))
 
@@ -149,7 +148,8 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
 
 
 def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',
-                      save_output=False, min_improvement=0.0):
+                      submission_dir = '.', save_output=False,
+                      min_improvement=0.0):
     problem = assert_read_problem(ramp_kit_dir)
     print_title('Blending {}'.format(problem.problem_title))
     X_train, y_train, X_test, y_test = assert_data(ramp_kit_dir, ramp_data_dir)
@@ -168,7 +168,8 @@ def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',
         predictions_valid_list = []
         predictions_test_list = []
         for submission in submissions:
-            module_path = os.path.join(ramp_kit_dir, 'submissions', submission)
+            module_path = os.path.join(
+                submission_dir, 'submissions', submission)
             training_output_path = os.path.join(module_path, 'training_output')
             fold_output_path = os.path.join(
                 training_output_path, 'fold_{}'.format(fold_i))

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from .combine import blend_on_fold
-from .io import load_y_pred
+from .io import load_y_pred, set_state
 from .pretty_print import print_title, print_df_scores
 from .notebook import execute_notebook, convert_notebook
 from .scoring import round_df_scores, mean_score_matrix
@@ -105,6 +105,9 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
                 training_output_path, 'fold_{}'.format(fold_i))
             if not os.path.exists(fold_output_path):
                 os.mkdir(fold_output_path)
+            if save_y_preds:
+                print(fold_output_path)
+                set_state('new', save_y_preds, fold_output_path)
         print_title('CV fold {}'.format(fold_i))
 
         predictions_valid, predictions_test, df_scores =\

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -155,7 +155,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
 
 
 def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',
-                      submission_dir='.', save_output=False,
+                      ramp_submission_dir='.', save_output=False,
                       min_improvement=0.0):
     problem = assert_read_problem(ramp_kit_dir)
     print_title('Blending {}'.format(problem.problem_title))
@@ -175,8 +175,7 @@ def blend_submissions(submissions, ramp_kit_dir='.', ramp_data_dir='.',
         predictions_valid_list = []
         predictions_test_list = []
         for submission in submissions:
-            module_path = os.path.join(
-                submission_dir, 'submissions', submission)
+            module_path = os.path.join(ramp_submission_dir, submission)
             training_output_path = os.path.join(module_path, 'training_output')
             fold_output_path = os.path.join(
                 training_output_path, 'fold_{}'.format(fold_i))


### PR DESCRIPTION
To unify local and remote training, we'll save everything that we need in the DB into files in `submissions/<submission>/training_output/fold_<i>`, including the state. After rsync, the script can check the file `state.txt` (in each fold), and act accordingly. If the state is `training_error`, `validation_error`, or `test_error`, `submissions/<submission>/training_output/fold_<i>/error.txt` will contain part of the stack that corresponds to the user submission.