### PR TITLE
[MRG] EHN: add submission path when to train a submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
     - pip install -r testing-requirements.txt
     - pip install .
 script:
-    - flake8 rampwf --ignore=F401,E211,E265,W503 --exclude rampwf/externals
+    - flake8 rampwf --ignore=F401,E211,E265,W503,W504 --exclude rampwf/externals
     - pytest -s -v --cov=rampwf rampwf
 after_success:
     - codecov

--- a/rampwf/tests/test_kits.py
+++ b/rampwf/tests/test_kits.py
@@ -53,7 +53,7 @@ def test_submission(path_kit):
             assert_submission(
                 ramp_kit_dir=path_kit,
                 ramp_data_dir=path_kit,
-                ramp_submission_dir=path_kit,
+                ramp_submission_dir=os.path.join(path_kit, 'submissions'),
                 submission=os.path.basename(sub), is_pickle=True,
                 save_y_preds=False, retrain=True)
 
@@ -62,13 +62,13 @@ def test_blending():
     assert_submission(
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
         ramp_data_dir=os.path.join(PATH, "kits", "iris"),
-        ramp_submission_dir=os.path.join(PATH, "kits", "iris"),
+        ramp_submission_dir=os.path.join(PATH, "kits", "iris", "submissions"),
         submission='starting_kit', is_pickle=True,
         save_y_preds=True, retrain=True)
     assert_submission(
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
         ramp_data_dir=os.path.join(PATH, "kits", "iris"),
-        ramp_submission_dir=os.path.join(PATH, "kits", "iris"),
+        ramp_submission_dir=os.path.join(PATH, "kits", "iris", "submissions"),
         submission='random_forest_10_10', is_pickle=True,
         save_y_preds=True, retrain=True)
     blend_submissions(

--- a/rampwf/tests/test_kits.py
+++ b/rampwf/tests/test_kits.py
@@ -53,6 +53,7 @@ def test_submission(path_kit):
             assert_submission(
                 ramp_kit_dir=path_kit,
                 ramp_data_dir=path_kit,
+                ramp_submission_dir=path_kit,
                 submission=os.path.basename(sub), is_pickle=True,
                 save_y_preds=False, retrain=True)
 

--- a/rampwf/tests/test_kits.py
+++ b/rampwf/tests/test_kits.py
@@ -62,11 +62,13 @@ def test_blending():
     assert_submission(
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
         ramp_data_dir=os.path.join(PATH, "kits", "iris"),
+        ramp_submission_dir=os.path.join(PATH, "kits", "iris"),
         submission='starting_kit', is_pickle=True,
         save_y_preds=True, retrain=True)
     assert_submission(
         ramp_kit_dir=os.path.join(PATH, "kits", "iris"),
         ramp_data_dir=os.path.join(PATH, "kits", "iris"),
+        ramp_submission_dir=os.path.join(PATH, "kits", "iris"),
         submission='random_forest_10_10', is_pickle=True,
         save_y_preds=True, retrain=True)
     blend_submissions(

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -32,6 +32,11 @@ def create_ramp_test_submission_parser():
                         type=str,
                         help='Directory containing the data. This directory'
                         ' should contain a "data" folder.')
+    parser.add_argument('--ramp_submission_dir',
+                        default='.',
+                        type=str,
+                        help='Directory where the submissions are stored. It '
+                        'should contain a "submissions" directory.')
     parser.add_argument('--submission',
                         default='starting_kit',
                         type=str,
@@ -87,6 +92,7 @@ def ramp_test_submission():
     for sub in submission:
         assert_submission(ramp_kit_dir=args.ramp_kit_dir,
                           ramp_data_dir=args.ramp_data_dir,
+                          ramp_submission_dir=args.ramp_submission_dir,
                           submission=sub,
                           is_pickle=is_pickle,
                           save_y_preds=save_y_preds,

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -33,7 +33,7 @@ def create_ramp_test_submission_parser():
                         help='Directory containing the data. This directory'
                         ' should contain a "data" folder.')
     parser.add_argument('--ramp_submission_dir',
-                        default='./submissions',
+                        default='submissions',
                         type=str,
                         help='Directory where the submissions are stored. It '
                         'should contain a "submissions" directory.')

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -342,7 +342,7 @@ def ramp_leaderboard():
     try:
         from ..externals.tabulate import tabulate
         print(tabulate(df, headers='keys', tablefmt='grid'))
-    except ImportError as ex:
+    except ImportError:
         print(df)
 
 

--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -33,7 +33,7 @@ def create_ramp_test_submission_parser():
                         help='Directory containing the data. This directory'
                         ' should contain a "data" folder.')
     parser.add_argument('--ramp_submission_dir',
-                        default='.',
+                        default='./submissions',
                         type=str,
                         help='Directory where the submissions are stored. It '
                         'should contain a "submissions" directory.')

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -61,7 +61,7 @@ def assert_score_types(ramp_kit_dir='.'):
 
 
 def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
-                      ramp_submission_dir='./submissions',
+                      ramp_submission_dir='submissions',
                       submission='starting_kit', is_pickle=False,
                       save_y_preds=False, retrain=False):
     """Helper to test a submission from a ramp-kit.

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -61,7 +61,7 @@ def assert_score_types(ramp_kit_dir='.'):
 
 
 def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
-                      ramp_submission_dir='.',
+                      ramp_submission_dir='./submissions',
                       submission='starting_kit', is_pickle=False,
                       save_y_preds=False, retrain=False):
     """Helper to test a submission from a ramp-kit.
@@ -72,7 +72,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
         The directory of the ramp-kit to be tested for submission.
     ramp_data_dir : str, default='.'
         The directory of the data.
-    ramp_submission_dir : str, default='.'
+    ramp_submission_dir : str, default='./submissions'
         The directory of the submissions.
     submission : str, default='starting_kit'
         The name of the submission to be tested.
@@ -91,8 +91,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     score_types = assert_score_types(ramp_kit_dir)
 
     # module_path = os.path.join(ramp_kit_dir, 'submissions', submission)
-    submission_path = os.path.join(ramp_submission_dir, 'submissions',
-                                   submission)
+    submission_path = os.path.join(ramp_submission_dir, submission)
     print_title('Training {} ...'.format(submission_path))
 
     training_output_path = ''

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -110,7 +110,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     for fold_i, fold in enumerate(cv):
         fold_output_path = ''
         if is_pickle or save_y_preds:
-            # creating <submission_path>/<submission>/training_output/fold_<i> dir
+            # creating <submission_path>/<submission>/training_output/fold_<i>
             fold_output_path = os.path.join(
                 training_output_path, 'fold_{}'.format(fold_i))
             if not os.path.exists(fold_output_path):
@@ -118,7 +118,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
         print_title('CV fold {}'.format(fold_i))
 
         predictions_valid, predictions_test, df_scores = \
-        run_submission_on_cv_fold(
+            run_submission_on_cv_fold(
                 problem, submission_path, X_train, y_train, X_test, y_test,
                 score_types, is_pickle, save_y_preds, fold_output_path,
                 fold, ramp_data_dir)

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -61,20 +61,28 @@ def assert_score_types(ramp_kit_dir='.'):
 
 
 def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
+                      ramp_submission_dir='.',
                       submission='starting_kit', is_pickle=False,
                       save_y_preds=False, retrain=False):
     """Helper to test a submission from a ramp-kit.
 
     Parameters
     ----------
-    ramp_kit_dir : str, (default='.')
-        the directory of the ramp-kit to be tested for submission
-
-    ramp_data_dir : str, (default='.')
-        the directory of the data
-
-    submission_name : str, (default='starting_kit')
-        the name of the submission to be tested
+    ramp_kit_dir : str, default='.'
+        The directory of the ramp-kit to be tested for submission.
+    ramp_data_dir : str, default='.'
+        The directory of the data.
+    ramp_submission_dir : str, default='.'
+        The directory of the submissions.
+    submission : str, default='starting_kit'
+        The name of the submission to be tested.
+    is_pickle : bool, default is False
+        Whether to pickle the model or not.
+    save_y_preds : bool, default is False
+        Whether to store the predictions.
+    retrain : bool, default is False
+        Whether to train the model on the full training set and test on the
+        test set.
     """
     problem = assert_read_problem(ramp_kit_dir)
     assert_title(ramp_kit_dir)
@@ -82,15 +90,17 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     cv = assert_cv(ramp_kit_dir, ramp_data_dir)
     score_types = assert_score_types(ramp_kit_dir)
 
-    module_path = os.path.join(ramp_kit_dir, 'submissions', submission)
-    print_title('Training {} ...'.format(module_path))
+    # module_path = os.path.join(ramp_kit_dir, 'submissions', submission)
+    submission_path = os.path.join(ramp_submission_dir, 'submissions',
+                                   submission)
+    print_title('Training {} ...'.format(submission_path))
 
     training_output_path = ''
     if is_pickle or save_y_preds:
-        # creating submissions/<submission>/training_output dir
-        training_output_path = os.path.join(module_path, 'training_output')
+        # creating <submission_path>/<submission>/training_output dir
+        training_output_path = os.path.join(submission_path, 'training_output')
         if not os.path.exists(training_output_path):
-            os.mkdir(training_output_path)
+            os.makedirs(training_output_path)
 
     # saving predictions for CV bagging after the CV loop
     predictions_valid_list = []
@@ -100,16 +110,16 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     for fold_i, fold in enumerate(cv):
         fold_output_path = ''
         if is_pickle or save_y_preds:
-            # creating submissions/<submission>/training_output/fold_<i> dir
+            # creating <submission_path>/<submission>/training_output/fold_<i> dir
             fold_output_path = os.path.join(
                 training_output_path, 'fold_{}'.format(fold_i))
             if not os.path.exists(fold_output_path):
-                os.mkdir(fold_output_path)
+                os.makedirs(fold_output_path)
         print_title('CV fold {}'.format(fold_i))
 
-        predictions_valid, predictions_test, df_scores =\
-            run_submission_on_cv_fold(
-                problem, module_path, X_train, y_train, X_test, y_test,
+        predictions_valid, predictions_test, df_scores = \
+        run_submission_on_cv_fold(
+                problem, submission_path, X_train, y_train, X_test, y_test,
                 score_types, is_pickle, save_y_preds, fold_output_path,
                 fold, ramp_data_dir)
         if save_y_preds:
@@ -135,7 +145,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
         print_title('Retrain scores')
         print_title('----------------------------')
         run_submission_on_full_train(
-            problem, module_path, X_train, y_train, X_test, y_test,
+            problem, submission_path, X_train, y_train, X_test, y_test,
             score_types, is_pickle, save_y_preds, training_output_path,
             ramp_data_dir)
     bag_submissions(

--- a/rampwf/utils/tests/test_command_line.py
+++ b/rampwf/utils/tests/test_command_line.py
@@ -22,15 +22,17 @@ def test_cmd_ramp_test_submission_parser():
     args = parser.parse_args([])
     assert args.ramp_kit_dir == '.'
     assert args.ramp_data_dir == '.'
+    assert args.ramp_submission_dir == '.'
     assert args.submission == 'starting_kit'
 
     # specifying keyword args
     parser = create_ramp_test_submission_parser()
     args = parser.parse_args([
         '--ramp_kit_dir', './titanic/', '--ramp_data_dir', './titanic/',
-        '--submission', 'other'])
+        '--ramp_submission_dir', './titanic', '--submission', 'other'])
     assert args.ramp_kit_dir == './titanic/'
     assert args.ramp_data_dir == './titanic/'
+    assert args.ramp_submission_dir == './titanic'
     assert args.submission == 'other'
 
 

--- a/rampwf/utils/tests/test_command_line.py
+++ b/rampwf/utils/tests/test_command_line.py
@@ -22,7 +22,7 @@ def test_cmd_ramp_test_submission_parser():
     args = parser.parse_args([])
     assert args.ramp_kit_dir == '.'
     assert args.ramp_data_dir == '.'
-    assert args.ramp_submission_dir == '.'
+    assert args.ramp_submission_dir == 'submissions'
     assert args.submission == 'starting_kit'
 
     # specifying keyword args


### PR DESCRIPTION
This PR allows to pass a new parameter `ramp_submission_dir` to specify a a directory where the submissions are stored. This is useful when dealing with the backend server.