### PR TITLE
Score reorder bug

### DIFF
--- a/rampwf/utils/pretty_print.py
+++ b/rampwf/utils/pretty_print.py
@@ -4,7 +4,6 @@ Utility methods to print the results in a terminal using term colors
 """
 from __future__ import print_function
 
-import numpy as np
 from pandas import option_context
 from ..externals.colored import stylize, fg, attr
 
@@ -29,15 +28,13 @@ def print_warning(str):
     print(stylize(str, fg(fg_colors['warning'])))
 
 
-def print_df_scores(df_scores, score_types, indent=''):
+def print_df_scores(df_scores, indent=''):
     """Pretty print the scores dataframe.
 
     Parameters
     ----------
     df_scores : pd.DataFrame
         the score dataframe
-    score_types : list of score types
-        a list of score types to use
     indent : str, default=''
         indentation if needed
     """

--- a/rampwf/utils/pretty_print.py
+++ b/rampwf/utils/pretty_print.py
@@ -41,15 +41,6 @@ def print_df_scores(df_scores, score_types, indent=''):
     indent : str, default=''
         indentation if needed
     """
-    try:
-        # try to re-order columns/rows in the printed array
-        # we may not have all train, valid, test, so need to select
-        index_order = np.array(['train', 'valid', 'test'])
-        ordered_index = index_order[np.isin(index_order, df_scores.index)]
-        df_scores = df_scores.loc[
-            ordered_index, [score_type.name for score_type in score_types]]
-    except Exception:
-        print_warning("Couldn't re-order the score matrix..")
     with option_context("display.width", 160):
         df_repr = repr(df_scores)
     df_repr_out = []

--- a/rampwf/utils/scoring.py
+++ b/rampwf/utils/scoring.py
@@ -4,10 +4,36 @@ Scoring utilities
 """
 import numpy as np
 import pandas as pd
+from .pretty_print import print_warning
+
+
+def reorder_df_scores(df_scores, score_types):
+    """Reorder scores according to the order in score_types.
+
+    Parameters
+    ----------
+    df_scores : pd.DataFrame
+        the score dataframe
+    score_types : list of score types
+
+    Returns
+    -------
+    df_scores : the dataframe with reordered scores
+    """
+    try:
+        # try to re-order columns/rows in the printed array
+        # we may not have all train, valid, test, so need to select
+        index_order = np.array(['train', 'valid', 'test'])
+        ordered_index = index_order[np.isin(index_order, df_scores.index)]
+        df_scores = df_scores.loc[
+            ordered_index, [score_type.name for score_type in score_types]]
+    except Exception:
+        print_warning("Couldn't re-order the score matrix..")
+    return df_scores
 
 
 def mean_score_matrix(df_scores_list, score_types):
-    """Construct a mean ± std score dataframe from a list of score dataframes.
+    u"""Construct a mean ± std score dataframe from a list of score dataframes.
 
     Parameters
     ----------
@@ -58,6 +84,7 @@ def score_matrix_from_scores(score_types, steps, scoress):
     df_scores = pd.DataFrame(results)
     df_scores = df_scores.set_index(['step', 'score'])['value']
     df_scores = df_scores.unstack()
+    df_scores = reorder_df_scores(df_scores, score_types)
     return df_scores
 
 

--- a/rampwf/utils/submission.py
+++ b/rampwf/utils/submission.py
@@ -338,11 +338,10 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
         test_idx = ([valid_is for (train_is, valid_is) in cv]
                     if step == 'valid' else None)
         score_dict = {}
-        for score_type in score_types:
+        for st in score_types:
             pred, scores = get_score_cv_bags(
-                score_type, pred_list, gt_list, test_is_list=test_idx
-            )
-            score_dict[score_type.name] = {
+                st, pred_list, gt_list, test_is_list=test_idx)
+            score_dict[st.name] = {
                 key: val for key, val in enumerate(scores)}
         bagged_scores[step] = score_dict
         # the predictions will always be the same for all score and we store

--- a/rampwf/utils/submission.py
+++ b/rampwf/utils/submission.py
@@ -7,14 +7,13 @@ import os
 from collections import Iterable
 from collections import OrderedDict
 
-import numpy as np
 import pandas as pd
 import cloudpickle as pickle
 
 from .io import save_y_pred
 from .combine import get_score_cv_bags
 from .pretty_print import print_title, print_df_scores, print_warning
-from .scoring import score_matrix, round_df_scores, score_matrix_from_scores
+from .scoring import score_matrix, round_df_scores
 
 
 def save_submissions(problem, y_pred, data_path='.', output_path='.',

--- a/rampwf/utils/submission.py
+++ b/rampwf/utils/submission.py
@@ -13,7 +13,7 @@ import cloudpickle as pickle
 from .io import save_y_pred
 from .combine import get_score_cv_bags
 from .pretty_print import print_title, print_df_scores, print_warning
-from .scoring import score_matrix, round_df_scores
+from .scoring import score_matrix, round_df_scores, reorder_df_scores
 
 
 def save_submissions(problem, y_pred, data_path='.', output_path='.',
@@ -259,7 +259,7 @@ def run_submission_on_full_train(problem, module_path, X_train, y_train,
                                      ('test', predictions_test)]),
         )
         df_scores_rounded = round_df_scores(df_scores, score_types)
-        print_df_scores(df_scores_rounded, score_types, indent='\t')
+        print_df_scores(df_scores_rounded, indent='\t')
 
         if save_y_preds:
             save_submissions(
@@ -275,7 +275,7 @@ def run_submission_on_full_train(problem, module_path, X_train, y_train,
             predictions=OrderedDict([('train', predictions_train)]),
         )
         df_scores_rounded = round_df_scores(df_scores, score_types)
-        print_df_scores(df_scores_rounded, score_types, indent='\t')
+        print_df_scores(df_scores_rounded, indent='\t')
 
         if save_y_preds:
             save_submissions(
@@ -320,9 +320,10 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
     print_title('----------------------------')
     score_type_index = (slice(None) if score_type_index is None
                         else score_type_index)
-    score_type = problem.score_types[score_type_index]
-    score_type = ([score_type] if not isinstance(score_type, Iterable)
-                  else score_type)
+    score_types = problem.score_types[score_type_index]
+    score_types = (
+        [score_types] if not isinstance(score_types, Iterable)
+        else score_types)
 
     # placeholder to store the scores and predictions
     bagged_scores = {}
@@ -337,12 +338,12 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
         test_idx = ([valid_is for (train_is, valid_is) in cv]
                     if step == 'valid' else None)
         score_dict = {}
-        for score in score_type:
+        for score_type in score_types:
             pred, scores = get_score_cv_bags(
-                score, pred_list, gt_list, test_is_list=test_idx
+                score_type, pred_list, gt_list, test_is_list=test_idx
             )
-            score_dict[score.name] = {key: val
-                                      for key, val in enumerate(scores)}
+            score_dict[score_type.name] = {
+                key: val for key, val in enumerate(scores)}
         bagged_scores[step] = score_dict
         # the predictions will always be the same for all score and we store
         # only a single instance
@@ -355,22 +356,21 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
 
     df_scores = pd.concat({step: pd.DataFrame(scores)
                            for step, scores in bagged_scores.items()})
-    df_scores.columns = df_scores.columns.rename('scores')
+    df_scores.columns = df_scores.columns.rename('score')
     df_scores.index = df_scores.index.rename(['step', 'n_bag'])
+    # bagging learning curves can be plotted on this df_scores
 
     # prepare the bagged scores which will be printed.
-    numerical_precision = pd.Series([score.precision for score in score_type],
-                                    index=[score.name for score in score_type])
     highest_level = df_scores.index.get_level_values('n_bag').max()
-    df_scores_rounded = df_scores.loc[(slice(None), highest_level), :].round(
-        numerical_precision
-    )
-    df_scores_rounded.index = df_scores_rounded.index.droplevel('n_bag')
-    print_df_scores(df_scores_rounded, score_type, indent='\t')
+    df_scores = df_scores.loc[(slice(None), highest_level), :]
+    df_scores.index = df_scores.index.droplevel('n_bag')
+    df_scores = reorder_df_scores(df_scores, score_types)
+    df_scores = round_df_scores(df_scores, score_types)
+    print_df_scores(df_scores, indent='\t')
 
     if save_y_preds:
-        bagged_scores_filename = os.path.join(training_output_path,
-                                              'bagged_scores.csv')
+        bagged_scores_filename = os.path.join(
+            training_output_path, 'bagged_scores.csv')
         df_scores.to_csv(bagged_scores_filename)
 
 

--- a/rampwf/utils/submission.py
+++ b/rampwf/utils/submission.py
@@ -358,6 +358,10 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
     df_scores.columns = df_scores.columns.rename('score')
     df_scores.index = df_scores.index.rename(['step', 'n_bag'])
     # bagging learning curves can be plotted on this df_scores
+    if save_y_preds:
+        bagged_scores_filename = os.path.join(
+            training_output_path, 'bagged_scores.csv')
+        df_scores.to_csv(bagged_scores_filename)
 
     # prepare the bagged scores which will be printed.
     highest_level = df_scores.index.get_level_values('n_bag').max()
@@ -366,11 +370,6 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
     df_scores = reorder_df_scores(df_scores, score_types)
     df_scores = round_df_scores(df_scores, score_types)
     print_df_scores(df_scores, indent='\t')
-
-    if save_y_preds:
-        bagged_scores_filename = os.path.join(
-            training_output_path, 'bagged_scores.csv')
-        df_scores.to_csv(bagged_scores_filename)
 
 
 def pickle_model(fold_output_path, trained_workflow, model_name='model.pkl'):

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -125,7 +125,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
             filename = os.path.join(fold_output_path, 'scores.csv')
             df_scores.to_csv(filename)
         df_scores_rounded = round_df_scores(df_scores, score_types)
-        print_df_scores(df_scores_rounded, score_types, indent='\t')
+        print_df_scores(df_scores_rounded, indent='\t')
 
         # saving predictions for CV bagging after the CV loop
         df_scores_list.append(df_scores)
@@ -136,7 +136,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     print_title('Mean CV scores')
     print_title('----------------------------')
     df_mean_scores = mean_score_matrix(df_scores_list, score_types)
-    print_df_scores(df_mean_scores, score_types, indent='\t')
+    print_df_scores(df_mean_scores, indent='\t')
 
     if retrain:
         # We retrain on the full training set

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -150,7 +150,7 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
     bag_submissions(
         problem, cv, y_train, y_test, predictions_valid_list,
         predictions_test_list, training_output_path,
-        ramp_data_dir=ramp_data_dir, score_type_index=0,
+        ramp_data_dir=ramp_data_dir, score_type_index=None,
         save_y_preds=save_y_preds)
 
 


### PR DESCRIPTION
Score matrix was reordered when doing `unstack()` so precisions specified in `problem.score_types` were applied in the wrong order before printing. I added an explicit `reorder_df_scores` which is called before rounding and printing. In addition, I did some naming cosmetics in `bag_submissions` (ie `score_types` instead of `score_type` and `score_type` instead of `score`) to be consistent.