### PR TITLE
MAINT: use build-in round for df instead of ours

### DIFF
--- a/rampwf/utils/scoring.py
+++ b/rampwf/utils/scoring.py
@@ -117,23 +117,3 @@ def score_matrix(score_types, ground_truth, predictions):
         score_type.score_function(ground_truth[step], predictions[step])
         for score_type in score_types] for step in ground_truth]
     return score_matrix_from_scores(score_types, steps, scoress)
-
-
-def round_df_scores(df_scores, score_types):
-    """Round scores to the precision set in the score type.
-
-    Parameters
-    ----------
-    df_scores : pd.DataFrame
-        the score dataframe
-    score_types : list of score types
-
-    Returns
-    -------
-    df_scores : the dataframe with rounded scores
-    """
-    df_scores_copy = df_scores.copy()
-    for column, score_type in zip(df_scores_copy, score_types):
-        df_scores_copy[column] = [round(score, score_type.precision)
-                                  for score in df_scores_copy[column]]
-    return df_scores_copy

--- a/rampwf/utils/submission.py
+++ b/rampwf/utils/submission.py
@@ -13,7 +13,7 @@ import cloudpickle as pickle
 from .io import save_y_pred, set_state, print_submission_exception
 from .combine import get_score_cv_bags
 from .pretty_print import print_title, print_df_scores, print_warning
-from .scoring import score_matrix, round_df_scores, reorder_df_scores
+from .scoring import score_matrix, reorder_df_scores
 
 
 def save_submissions(problem, y_pred, data_path='.', output_path='.',
@@ -286,7 +286,8 @@ def run_submission_on_full_train(problem, module_path, X_train, y_train,
             predictions=OrderedDict([('train', predictions_train),
                                      ('test', predictions_test)]),
         )
-        df_scores_rounded = round_df_scores(df_scores, score_types)
+        map_score_precision = {st.name: st.precision for st in score_types}
+        df_scores_rounded = df_scores.round(map_score_precision)
         print_df_scores(df_scores_rounded, indent='\t')
 
         if save_output:
@@ -302,7 +303,8 @@ def run_submission_on_full_train(problem, module_path, X_train, y_train,
             ground_truth=OrderedDict([('train', ground_truth_train)]),
             predictions=OrderedDict([('train', predictions_train)]),
         )
-        df_scores_rounded = round_df_scores(df_scores, score_types)
+        map_score_precision = {st.name: st.precision for st in score_types}
+        df_scores_rounded = df_scores.round(map_score_precision)
         print_df_scores(df_scores_rounded, indent='\t')
 
         if save_output:
@@ -396,7 +398,10 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
     df_scores = df_scores.loc[(slice(None), highest_level), :]
     df_scores.index = df_scores.index.droplevel('n_bag')
     df_scores = reorder_df_scores(df_scores, score_types)
-    df_scores = round_df_scores(df_scores, score_types)
+
+    # round the dataframe
+    map_score_precision = {st.name: st.precision for st in score_types}
+    df_scores = df_scores.round(map_score_precision)
     print_df_scores(df_scores, indent='\t')
 
 

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -13,7 +13,7 @@ from .combine import blend_on_fold
 from .io import load_y_pred, set_state
 from .pretty_print import print_title, print_df_scores
 from .notebook import execute_notebook, convert_notebook
-from .scoring import round_df_scores, mean_score_matrix
+from .scoring import mean_score_matrix
 from .submission import (bag_submissions, run_submission_on_cv_fold,
                          run_submission_on_full_train)
 
@@ -124,7 +124,8 @@ def assert_submission(ramp_kit_dir='.', ramp_data_dir='.',
         if save_output:
             filename = os.path.join(fold_output_path, 'scores.csv')
             df_scores.to_csv(filename)
-        df_scores_rounded = round_df_scores(df_scores, score_types)
+        map_score_precision = {st.name: st.precision for st in score_types}
+        df_scores_rounded = df_scores.round(map_score_precision)
         print_df_scores(df_scores_rounded, indent='\t')
 
         # saving predictions for CV bagging after the CV loop


### PR DESCRIPTION
Reverting some changes from my previous PR.
We should use the built-in functionalities from pandas in this case.