### PR TITLE
MNT update the minium version of scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.13
 scipy>=0.19
 pandas>=0.19.2
-scikit-learn>=0.18
+scikit-learn>=0.22
 cloudpickle
 click

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ CLASSIFIERS = ['Intended Audience :: Science/Research',
                'Operating System :: MacOS',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7']
-INSTALL_REQUIRES = ['numpy', 'scipy', 'pandas', 'scikit-learn', 'joblib',
+INSTALL_REQUIRES = ['numpy', 'scipy', 'pandas', 'scikit-learn>=0.22', 'joblib',
                     'cloudpickle', 'click']
 EXTRAS_REQUIRE = {
     'tests': ['pytest', 'pytest-cov'],


### PR DESCRIPTION
`_safe_indexing` became private in `scikit-learn` 0.22 so we need at least this version.

I think that we should synchronize with the latest scikit-learn version anyway.