### PR TITLE
Improve pickle

### DIFF
--- a/rampwf/utils/submission.py
+++ b/rampwf/utils/submission.py
@@ -420,13 +420,22 @@ def pickle_model(fold_output_path, trained_workflow, model_name='model.pkl'):
     trained_workflow : a rampwf.workflow
         either the input workflow or the pickled and reloaded workflow
     """
+    msg = "Warning: model can't be pickled."
+    model_file = os.path.join(fold_output_path, model_name)
     try:
-        model_file = os.path.join(fold_output_path, model_name)
         with open(model_file, 'wb') as pickle_file:
             cloudpickle.dump(trained_workflow, pickle_file)
-        with open(model_file, 'rb') as pickle_file:
-            trained_workflow = cloudpickle.load(pickle_file)
-    except pickle.PickleError as e:
-        print_warning("Warning: model can't be pickled.")
+    except pickle.PicklingError as e:
+        print_warning(msg)
         print_warning(e)
+        return trained_workflow
+    else:
+        # check if dumped trained_workflow can be loaded
+        try:
+            with open(model_file, 'rb') as pickle_file:
+                trained_workflow = cloudpickle.load(pickle_file)
+        except Exception as e:
+            print_warning(msg)
+            print_warning(e)
+
     return trained_workflow

--- a/rampwf/utils/submission.py
+++ b/rampwf/utils/submission.py
@@ -4,11 +4,12 @@ Utilities to manage the submissions
 """
 import os
 import time
+import pickle
 from collections.abc import Iterable
 from collections import OrderedDict
 
 import pandas as pd
-import cloudpickle as pickle
+import cloudpickle
 
 from .io import save_y_pred, set_state, print_submission_exception
 from .combine import get_score_cv_bags
@@ -404,7 +405,7 @@ def bag_submissions(problem, cv, y_train, y_test, predictions_valid_list,
 def pickle_model(fold_output_path, trained_workflow, model_name='model.pkl'):
     """Pickle and reload trained workflow.
 
-    If workflow can't be pickled, print warning and return origina' workflow.
+    If workflow can't be pickled, print warning and return original workflow.
 
     Parameters
     ----------
@@ -422,10 +423,10 @@ def pickle_model(fold_output_path, trained_workflow, model_name='model.pkl'):
     try:
         model_file = os.path.join(fold_output_path, model_name)
         with open(model_file, 'wb') as pickle_file:
-            pickle.dump(trained_workflow, pickle_file)
-        with open(model_file, 'r') as pickle_file:
-            trained_workflow = pickle.load(pickle_file)
-    except Exception as e:
+            cloudpickle.dump(trained_workflow, pickle_file)
+        with open(model_file, 'rb') as pickle_file:
+            trained_workflow = cloudpickle.load(pickle_file)
+    except pickle.PickleError as e:
         print_warning("Warning: model can't be pickled.")
         print_warning(e)
     return trained_workflow

--- a/rampwf/utils/tests/test_submission.py
+++ b/rampwf/utils/tests/test_submission.py
@@ -1,0 +1,22 @@
+import tempfile
+import pickle
+
+from rampwf.utils.submission import pickle_model
+
+
+def test_pickle_model(capsys):
+    # check that warning is raised if trained workflow cannot be pickled
+
+    # object raising PicklingError when dumped
+    class Unpicklable(object):
+
+        def __reduce__(self):
+            raise pickle.PicklingError("not picklable")
+
+    tmpdir = tempfile.mkdtemp()
+    tmpfile = 'tmp.pkl'
+
+    pickle_model(tmpdir, Unpicklable(), model_name=tmpfile)
+    msg = "Warning: model can't be pickled."
+    captured = capsys.readouterr()
+    assert msg in captured.out


### PR DESCRIPTION
Pickling was working but raising a non related warning because the file was not read as a binary file. An error should have been raised instead of a warning saying that the model cannot be pickled.

The pickled file is now read as a binary file and only Pickle errors are caught by the try except clause.

PS: this is also fixing two non related flake8 errors to make Travis happy