### PR TITLE
Fix error message in _filter_and_sort_leaderboard_df

### DIFF
--- a/rampwf/utils/command_line.py
+++ b/rampwf/utils/command_line.py
@@ -411,7 +411,7 @@ def _filter_and_sort_leaderboard_df(
                 cols_s = '\n'.join(list(valid_cols))
                 raise ValueError(
                     'Column "{}" does not exist.'
-                    ' Available columns are : \n'.format(col, cols_s))
+                    ' Available columns are : \n{}'.format(col, cols_s))
         show_cols = cols
     elif metric is not None:
         if 'train_' + metric not in df.columns:
@@ -437,7 +437,7 @@ def _filter_and_sort_leaderboard_df(
                 cols_s = '\n'.join(list(valid_cols))
                 raise ValueError(
                     'Column "{}" does not exist.'
-                    ' Available columns are : \n'.format(col, cols_s))
+                    ' Available columns are :\n{}'.format(col, cols_s))
     elif metric:
         sort_cols = ['{}_{}_mean'.format(step, metric)
                      for step in ('test', 'valid', 'train')]


### PR DESCRIPTION
Fix lint which was causing CIs to fail:

> rampwf/utils/command_line.py:413:21: F523 '...'.format(...) has unused arguments at position(s): 1
rampwf/utils/command_line.py:439:21: F523 '...'.format(...) has unused arguments at position(s): 1
The command "flake8 rampwf --ignore=F401,E211,E265,W503,W504 --exclude rampwf/externals" exited with 1.