### PR TITLE
DOC Update prepare_data instructions

### DIFF
--- a/doc/data.rst
+++ b/doc/data.rst
@@ -48,7 +48,8 @@ only the data files are required for deployment.
   Titanic challenge as an example.
 * ``README.md`` - a quick summary of how to run ``prepare_data.py``, mostly
   serves as an introduction on GitHub.
-* ``data/`` - directory containing the private training and test data.
+* ``data/`` - directory that should ultimately contain the public and private
+  datasets, after running ``prepare_data.py``. See :ref:`prepare_data_script`.
 
 Generally, the data files for a RAMP challenge are kept in a repository
 in the `ramp-data <https://github.com/ramp-data>`_ organisation on GitHub. This
@@ -65,15 +66,24 @@ on the raw data and split the data into appropriate subsets as detailed above.
 It is a good way to document all the data cleaning steps and enables you to
 download (if required) and split the raw data easily on the RAMP server. It
 also helps to ensure that same data challenge can be deployed again using
-consistent training and test data subsets. As an example, the Titanic
-challenge, which has a very basic ``prepare_data.py`` file, is shown below::
+consistent training and test data subsets.
 
-    # In this case the data requires no cleaning and we have a predefined
-    # train/test cut so we are not splitting the data here
+The raw data may be stored in the ``data/`` directory or can be downloaded from
+elsewhere. Ultimately, there should be 4 data files in the ``data/``
+directory, detailed below, after running ``prepare_data.py`` script.
+
+As an example, the ``prepare_data.py`` for Titanic challenge, which stores the
+raw data in ``data/``, is shown below::
+
+    # 1 - read in or download the data.
     df_train = pd.read_csv(os.path.join('data', 'train.csv'))
-    df_test = pd.read_csv(os.path.join('data', 'test.csv'))  # noqa
+    df_test = pd.read_csv(os.path.join('data', 'test.csv'))
 
-    # In this case the private training data was also used as the public data
+    # 2 - Perform any data cleaning and split into private train/test subsets,
+    # if required. Neither steps required in this case.
+
+    # 3 - Split public train/test subsets. In this case the private training
+    # data will be used as the public data
     df_public = df_train
     df_public_train, df_public_test = train_test_split(
         df_public, test_size=0.2, random_state=57)
@@ -82,7 +92,8 @@ challenge, which has a very basic ``prepare_data.py`` file, is shown below::
     df_public_test.to_csv(os.path.join('data', 'public', 'test.csv'), index=False)
 
 Note that the private training data was also used as the public data, due to
-the small size of this dataset. At this stage we have 4 files:
+the small size of this dataset. At this stage we have 4 files in the ``data/``
+directory:
 
 * ``train.csv`` - private training data.
 * ``test.csv`` - private testing data. **This should never be made public.**
@@ -92,12 +103,4 @@ the small size of this dataset. At this stage we have 4 files:
   data ``train.csv``.
 
 The public data files should be copied over to the 'ramp kit' directory
-when deploying an event on a RAMP server.
-
-Raw data files
-==============
-
-In the Titanic example, the raw data was stored in the data directory. If your
-raw data is to be downloaded from elsewhere, you can download the data in
-the ``prepare_data.py`` file then clean and create the required private and
-public datasets.
+on a RAMP server, when deploying an event.

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -9,28 +9,54 @@ The data for your RAMP challenge should consist of:
   compute scores for each submission for the private leaderboard. It is
   essential that this data remains private from participants.
 * **Private training data** - this data is also stored on the RAMP server and will
-  be used by the server to train each submission. It is good practice that this
+  be used by the server to train each submission. It is preferred that this
   is completely independent of the public data. However, if you have a small
   data size, it is also fine for this data to be the same as the public data.
 * **Public data** - this data is made available to the participants. It needs to be
   split into 'public training data' and 'public testing' subsets. This is
   because the same script is used to test submissions when you run RAMP locally
   and on the RAMP server, when you make a submission to a RAMP event. Therefore,
-  ``get_train_data()`` and ``get_test_data()`` (see :ref:`Data I/O <in-out>`)
-  needs to work
-  both locally and on the RAMP server. This is generally achieved by naming the
-  public test and train dataset the same as the private test and train dataset.
+  ``get_train_data()`` and ``get_test_data()`` from the ``problem.py`` script
+  (see :ref:`Data I/O <in-out>`) needs to work
+  both locally and on the RAMP server. This is generally achieved by having
+  both a public test and train dataset and naming these the same as the private
+  test and train dataset.
   See :ref:`prepare-ramp-data` for an example.
 
 .. _prepare-ramp-data:
 
-RAMP-data
+RAMP data
 =========
 
-By convention all the data files for a RAMP challenge are kept in a repository
+A data directory is required to deploy your challenge on a RAMP sever.
+Strictly speaking, it is not required if you simply wish to use RAMP worflow
+locally. The data directory should be separate from the starting kit directory
+(see :ref:`directory-structure`).
+
+The data directory should consist of the following files, though technically,
+only the ``prepare_data.py`` file is required.
+
+* ``prepare_data.py`` - script to clean and split the raw data, see
+  :ref:`prepare_data_script`.
+* ``requirements.txt`` - file listing required packages used in
+  ``prepare_data.py``.
+* ``.travis.yml`` - Travis continuous integration configuration file. This
+  should run the ``prepare_data.py`` and is set to run regularly so we are
+  alerted to any problems. See the `configuration file
+  <https://github.com/ramp-data/titanic/blob/master/.travis.yml>`_ of the
+  Titanic challenge as an example.
+* ``README.md`` - a quick summary of how to run ``prepare_data.py``, mostly
+  serves as an introduction on GitHub.
+
+Generally, the data files for a RAMP challenge are kept in a repository
 in the `ramp-data <https://github.com/ramp-data>`_ organisation on GitHub. This
 is always a private repository and all data, public and private, can be kept
 here, if size permits.
+
+.. _prepare_data_script:
+
+The prepare_data script
+***********************
 
 A ``prepare_data.py`` script should also be stored here. This script should
 perform any data cleaning steps on the original data and split the data into
@@ -46,56 +72,28 @@ a very basic ``prepare_data.py`` file, is shown below::
     # In this case the private training data was also used as the public data
     df_public = df_train
     df_public_train, df_public_test = train_test_split(
-        df_public, test_size=0.2, random_state=57) 
+        df_public, test_size=0.2, random_state=57)
         # specify the random_state to ensure reproducibility
-    df_public_train.to_csv(os.path.join('data', 'public_train.csv'), index=False)
-    df_public_test.to_csv(os.path.join('data', 'public_test.csv'), index=False)
+    df_public_train.to_csv(os.path.join('data', 'public', 'train.csv'), index=False)
+    df_public_test.to_csv(os.path.join('data', 'public', 'test.csv'), index=False)
 
 Note that the private training data was also used as the public data, due to
 the small size of this dataset. At this stage we have 4 files:
 
 * ``train.csv`` - private training data.
-* ``test.csv`` - private testing data. This should never be made public.
-* ``public_train.csv`` - in this case, this was a subset of the private
+* ``test.csv`` - private testing data. **This should never be made public.**
+* ``public/train.csv`` - in this case, this was a subset of the private
   training data ``train.csv``.
-* ``public_test.csv`` - in this case, this was a subset of the private training
+* ``public/test.csv`` - in this case, this was a subset of the private training
   data ``train.csv``.
 
-We now need to copy the public data files ``public_train.csv`` and
-``public_test.csv`` into the 'ramp-kits' directory. Note that the script
-assumes the file directory structure::
+The public data files should be copied over to the 'ramp kit' directory
+when deploying an event on a RAMP server.
 
-        <base_dir>
-        ├── <ramp_kits_dir>/
-        |   └── <ramp_name>/ # the starting kit would be in here
-        |       └── data/
-        └── <ramp_data_dir>/
-            └── <ramp_name>/ # ramp data files and prepare_data.py file are here
-                └── data/
+Data files
+==========
 
-The public files are being copied from the ``ramp_data_dir/data`` directory
-into the ``ramp_kits_dir/data`` directory. They are also being renamed to
-``train.csv`` and ``test.csv``, the same filenames as the private data in
-``ramp_data_dir/data``. This is because, as mentioned above, the same script is
-used to test submissions locally and on the RAMP server.
-
-.. code-block:: python 
-
-    # copy starting kit files to <ramp_kits_dir>/<ramp_name>/data
-    copyfile(
-        os.path.join('data', 'public_train.csv'),
-        os.path.join(ramp_kits_dir, ramp_name, 'data', 'train.csv')
-    )
-    copyfile(
-        os.path.join('data', 'public_test.csv'),
-        os.path.join(ramp_kits_dir, ramp_name, 'data', 'test.csv')
-    )
-
-.. _download-data:
-
-Downloading data
-================
-
-If your data is to be downloaded from elsewhere, you can download the data in
+In the Titanic example, the raw data was stored in the data directory. If your
+data is to be downloaded from elsewhere, you can download the data in
 the ``prepare_data.py`` file then clean and create the required private and
 public datasets.

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -102,5 +102,26 @@ directory:
 * ``public/test.csv`` - in this case, this was a subset of the private training
   data ``train.csv``.
 
-The public data files should be copied over to the 'ramp kit' directory
+The public data files need to be copied over to the starting kit directory
+(``ramp-kits/<starting_kit_name>/data/``, see :ref:`directory-structure`),
 on a RAMP server, when deploying an event.
+
+The data directory should look something like this::
+
+    <starting_kit_name>/    # root data directory
+    ├── README.md
+    ├── requirements.txt
+    ├── .travis.yml
+    ├── prepare_data.py
+    └── data/
+        ├── train.csv     # any data file format acceptable
+        ├── test.csv
+        └── public/
+            ├── train.csv
+            └── test.csv
+
+Strictly, only the ``data/`` directory is required to deploy an event on the
+RAMP server, though it is good practice to include the other files.
+
+See :ref:`directory-structure` for the structure of the data directory
+relative to the starting kit directory.

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -47,6 +47,7 @@ only the ``prepare_data.py`` file is required.
   Titanic challenge as an example.
 * ``README.md`` - a quick summary of how to run ``prepare_data.py``, mostly
   serves as an introduction on GitHub.
+* ``data/`` - directory containing the private training and test data.
 
 Generally, the data files for a RAMP challenge are kept in a repository
 in the `ramp-data <https://github.com/ramp-data>`_ organisation on GitHub. This
@@ -90,10 +91,10 @@ the small size of this dataset. At this stage we have 4 files:
 The public data files should be copied over to the 'ramp kit' directory
 when deploying an event on a RAMP server.
 
-Data files
-==========
+Raw data files
+==============
 
 In the Titanic example, the raw data was stored in the data directory. If your
-data is to be downloaded from elsewhere, you can download the data in
+raw data is to be downloaded from elsewhere, you can download the data in
 the ``prepare_data.py`` file then clean and create the required private and
 public datasets.

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -60,13 +60,13 @@ The prepare_data script
 ***********************
 
 A ``prepare_data.py`` script should also be stored here. This script should
-perform any data cleaning steps on the original data and split the data into
+perform any data cleaning steps on the raw data and split the data into
 the appropriate subsets as detailed above. It is a good way to document all
 the data cleaning steps. As an example, the Titanic challenge, which has
 a very basic ``prepare_data.py`` file, is shown below::
 
-    # In this case we have a predefined train/test cut so we are not splitting
-    # the data here
+    # In this case the data requires no cleaning and we have a predefined
+    # train/test cut so we are not splitting the data here
     df_train = pd.read_csv(os.path.join('data', 'train.csv'))
     df_test = pd.read_csv(os.path.join('data', 'test.csv'))  # noqa
 

--- a/doc/data.rst
+++ b/doc/data.rst
@@ -34,9 +34,10 @@ locally. The data directory should be separate from the starting kit directory
 (see :ref:`directory-structure`).
 
 The data directory should consist of the following files, though technically,
-only the ``prepare_data.py`` file is required.
+only the data files are required for deployment.
 
-* ``prepare_data.py`` - script to clean and split the raw data, see
+* ``prepare_data.py`` - script to clean and split the raw data, ensuring that
+  events can be deployed repeated with consistent data. See
   :ref:`prepare_data_script`.
 * ``requirements.txt`` - file listing required packages used in
   ``prepare_data.py``.
@@ -59,11 +60,13 @@ here, if size permits.
 The prepare_data script
 ***********************
 
-A ``prepare_data.py`` script should also be stored here. This script should
-perform any data cleaning steps on the raw data and split the data into
-the appropriate subsets as detailed above. It is a good way to document all
-the data cleaning steps. As an example, the Titanic challenge, which has
-a very basic ``prepare_data.py`` file, is shown below::
+The ``prepare_data.py`` script should perform any data cleaning steps required
+on the raw data and split the data into appropriate subsets as detailed above.
+It is a good way to document all the data cleaning steps and enables you to
+download (if required) and split the raw data easily on the RAMP server. It
+also helps to ensure that same data challenge can be deployed again using
+consistent training and test data subsets. As an example, the Titanic
+challenge, which has a very basic ``prepare_data.py`` file, is shown below::
 
     # In this case the data requires no cleaning and we have a predefined
     # train/test cut so we are not splitting the data here

--- a/doc/using_kits.rst
+++ b/doc/using_kits.rst
@@ -45,7 +45,19 @@ The code file(s) (e.g., `estimator.py`) for each submission needs to be stored
 in their own folder, which then needs to be located within the `submissions`
 folder. The name of the folder containing the code file(s) is the name of
 the submission. For example, the code files for the submission named
-'my_submission' should be located at `submissions/my_submission`.
+'my_submission' should be located at `submissions/my_submission`. The file
+structure should look like this::
+
+    <starting_kit_name>/    # root starting-kit directory
+    ├── <various starting kit files>
+    ├── data/
+    |   ├── train.csv     # data for challenge
+    |   └── test.csv
+    └── submissions/
+        ├── <starting_kit>/       # example solution that comes with every kit
+        |   └── <submission_file.py>
+        └── <my_submission>/      # your first solution
+            └── <submission_file.py>
 
 To run a specific submission, you can use the `ramp-test` command line:
 

--- a/doc/using_kits.rst
+++ b/doc/using_kits.rst
@@ -44,7 +44,7 @@ Test a submission
 The code file(s) (e.g., `estimator.py`) for each submission needs to be stored
 in their own folder, which then needs to be located within the `submissions`
 folder. The name of the folder containing the code file(s) is the name of
-the submission. For example, the code files for the submission named
+the submission. For example, the code file(s) for the submission named
 'my_submission' should be located at `submissions/my_submission`. The file
 structure should look like this::
 
@@ -56,7 +56,7 @@ structure should look like this::
     └── submissions/
         ├── <starting_kit>/       # example solution that comes with every kit
         |   └── <submission_file.py>
-        └── <my_submission>/      # your first solution
+        └── <my_submission>/      # your first submission
             └── <submission_file.py>
 
 To run a specific submission, you can use the `ramp-test` command line:

--- a/doc/workflow.rst
+++ b/doc/workflow.rst
@@ -31,7 +31,7 @@ files/folders are required:
   :ref:`problem`.
 * ``submissions/`` - each solution to be tested should be stored in its own
   directory within ``submissions/``. The name of this new directory will serve
-  as the ID for the submission. If you wish to launch a RAMP chellenge you
+  as the ID for the submission. If you wish to launch a RAMP challenge you
   will need to provide an example solution within ``submissions/starting_kit/``.
   Even if you are not launching a RAMP challenge on `RAMP Studio`_, it is
   useful to have an example submission as it shows which files are required,
@@ -80,7 +80,8 @@ The base directory of a full RAMP starting-kit should thus look like::
     |   ├── train.csv     # any data file format acceptable
     |   └── test.csv
     └── submissions/
-        └── <starting_kit>/
+        └── <starting_kit>/      # example solution
+            └── <submission_file.py>
 
 If you wish to launch a RAMP challenge on `RAMP Studio`_ you will need to
 upload the full starting-kit to `ramp-kits <https://github.com/ramp-kits>`_.

--- a/doc/workflow.rst
+++ b/doc/workflow.rst
@@ -13,9 +13,15 @@ solutions to your predictive problem. In this section we walk you through what
 you need to do to either use RAMP workflow locally or to launch a RAMP
 challenge on RAMP studio.
 
+Data
+****
+
 First, you will need to prepare your data by cleaning, if necessary, and
 splitting it into the required public and private, test and training sets.
 See :ref:`data` for more details.
+
+Minimal requirements
+********************
 
 Next, to setup your predictive problem to use RAMP workflow, the following
 files/folders are required:
@@ -40,6 +46,9 @@ files/folders are required:
 
     $ python download_data.py
 
+Full starting-kit
+*****************
+
 Once you have the above files, it is quite easy to prepare the additional files
 required for a full RAMP 'starting kit'. These files are not
 required for RAMP workflow to function locally but are useful for participants
@@ -57,9 +66,11 @@ and are required to launch a RAMP challenge on `RAMP Studio`_.
 * ``README.md`` - this is the homepage when the challenge is on GitHub and
   should provide a quick start guide.
 
-The base directory of a full ramp-kit should thus look like::
+The files listed above should be stored in the same RAMP 'starting-kit'
+directory.
+The base directory of a full RAMP starting-kit should thus look like::
 
-    <ramp_kit_name>/    # root ramp-kit directory
+    <starting_kit_name>/    # root starting-kit directory
     ├── README.md
     ├── download_data.py (optional)
     ├── problem.py
@@ -70,6 +81,24 @@ The base directory of a full ramp-kit should thus look like::
         └── <starting_kit>/
 
 If you wish to launch a RAMP challenge on `RAMP Studio`_ you will need to
-upload the full ramp-kit to `ramp-kits <https://github.com/ramp-kits>`_.
+upload the full starting-kit to `ramp-kits <https://github.com/ramp-kits>`_.
+
+.. _directory-structure:
+
+Overall directory structure
+***************************
+
+To deploy a RAMP challenge on a RAMP server, you will need a 'starting kit'
+and a :ref:`'data' <prepare-ramp-data>` directory. These directories are
+generally stored with the following directory structure::
+
+    ├── ramp-kits/
+    |  ├── <starting_kit_one>   # starting kit directories for each challenge
+    |  └── <starting_kit_two>
+    └── ramp-data/
+       ├── <data_for_kit_one>   # data directories for each challenge
+       └── <data_for_kit_two>
+
+Note in the example above, there are two different RAMP challenges.
 
 .. _RAMP Studio: https://ramp.studio/

--- a/doc/workflow.rst
+++ b/doc/workflow.rst
@@ -50,11 +50,11 @@ Full starting-kit
 *****************
 
 Once you have the above files, it is quite easy to prepare the additional files
-required for a full RAMP 'starting kit'. These files are not
+required for a full RAMP 'starting-kit'. These files are not
 required for RAMP workflow to function locally but are useful for participants
 and are required to launch a RAMP challenge on `RAMP Studio`_.
 
-* starting kit notebook - this is a jupyter notebook that introduces the
+* starting-kit notebook - this is a jupyter notebook that introduces the
   predictive problem, provides some background information, exploratory
   data analysis and data visualisation, explains the workflow and provides a
   simple example solution. This example solution should generally be the same
@@ -76,7 +76,9 @@ The base directory of a full RAMP starting-kit should thus look like::
     ├── problem.py
     ├── requirements.txt
     ├── <ramp_kit_name>_starting_kit.ipynb
-    ├── data
+    ├── data/
+    |   ├── train.csv     # any data file format acceptable
+    |   └── test.csv
     └── submissions/
         └── <starting_kit>/
 
@@ -88,17 +90,18 @@ upload the full starting-kit to `ramp-kits <https://github.com/ramp-kits>`_.
 Overall directory structure
 ***************************
 
-To deploy a RAMP challenge on a RAMP server, you will need a 'starting kit'
+To deploy a RAMP challenge on a RAMP server, you will need a 'starting-kit'
 and a :ref:`'data' <prepare-ramp-data>` directory. These directories are
 generally stored with the following directory structure::
 
     ├── ramp-kits/
-    |  ├── <starting_kit_one>   # starting kit directories for each challenge
+    |  ├── <starting_kit_one>   # root starting-kit directories for each challenge
     |  └── <starting_kit_two>
     └── ramp-data/
-       ├── <data_for_kit_one>   # data directories for each challenge
+       ├── <data_for_kit_one>   # root data directories for each challenge
        └── <data_for_kit_two>
 
-Note in the example above, there are two different RAMP challenges.
+Note in the example above, there are **two different** RAMP challenges, with
+corresponding starting-kit and data directories for each.
 
 .. _RAMP Studio: https://ramp.studio/

--- a/doc/workflow.rst
+++ b/doc/workflow.rst
@@ -95,11 +95,11 @@ and a :ref:`'data' <prepare-ramp-data>` directory. These directories are
 generally stored with the following directory structure::
 
     ├── ramp-kits/
-    |  ├── <starting_kit_one>   # root starting-kit directories for each challenge
-    |  └── <starting_kit_two>
+    |   ├── <starting_kit_one>   # root starting-kit directories for each challenge
+    |   └── <starting_kit_two>
     └── ramp-data/
-       ├── <data_for_kit_one>   # root data directories for each challenge
-       └── <data_for_kit_two>
+        ├── <data_for_kit_one>   # root data directories for each challenge
+        └── <data_for_kit_two>
 
 Note in the example above, there are **two different** RAMP challenges, with
 corresponding starting-kit and data directories for each.


### PR DESCRIPTION
Update documentation to instruct that `prepare_data.py` does not copy the public data files to the 'ramp-kits' directory. This should be done on the server to be robust to different server file configurations.

Made some clarifications as well.

cc @glemaitre @agramfort 