### PR TITLE
[MRG] Fix CI with keras version

### DIFF
--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -9,6 +9,6 @@ netCDF4
 xarray
 scikit-image
 joblib
-keras; python_version >= '3.5' or (python_version == '2.7' and sys_platform != 'win32')
+keras<2.4; python_version >= '3.5' or (python_version == '2.7' and sys_platform != 'win32')
 tensorflow == 2.0.1; python_version >= '3.5' or (python_version == '2.7' and sys_platform != 'win32')
 


### PR DESCRIPTION
Fixes #239 

Specifies keras version in `testing-requirements.txt` for compatibility with current tensorflow version.