### PR TITLE
Setting display.width to None

### DIFF
--- a/rampwf/utils/pretty_print.py
+++ b/rampwf/utils/pretty_print.py
@@ -54,7 +54,7 @@ def print_df_scores(df_scores, indent=''):
     indent : str, default=''
         indentation if needed
     """
-    with option_context("display.width", 160):
+    with option_context("display.width", None):
         df_repr = repr(df_scores)
     df_repr_out = []
     for line, color_key in zip(df_repr.splitlines(),


### PR DESCRIPTION
Is there a reason why we print score with a fixed width of 160 [here]( https://github.com/paris-saclay-cds/ramp-workflow/blob/master/rampwf/utils/pretty_print.py#L57 ) ?

Setting `display.width` to 0 would allow pandas to autodetects the size of terminal window, avoiding useless shortening in the printed scores