### PR TITLE
FIX encoding for new nbconvert version

### DIFF
--- a/rampwf/utils/notebook.py
+++ b/rampwf/utils/notebook.py
@@ -9,7 +9,7 @@ import sys
 
 
 def delete_line_from_file(f_name, line_to_delete):
-    with open(f_name, "r+") as f:
+    with open(f_name, "r+", encoding='utf-8') as f:
         lines = f.readlines()
         f.seek(0)
         for line in lines:


### PR DESCRIPTION
Appveyor is red now that nbconvert is installed with a version higher than 6. It was green when using a version < 6.

Trying to fix it by forcing utf8 encoding when reading the notebook. Note that the notebook is written to a file with an utf8 encoding (https://github.com/paris-saclay-cds/ramp-workflow/blob/master/rampwf/utils/notebook.py#L59)