### PR TITLE
CI Force python 3.8

### DIFF
--- a/ci_tools/circle/build_doc.sh
+++ b/ci_tools/circle/build_doc.sh
@@ -10,7 +10,7 @@ export PATH="$MINICONDA_PATH/bin:$PATH"
 conda update --yes --quiet conda
 
 # create the environment
-conda create --name testenv python=3
+conda create --name testenv python=3.8
 source activate testenv
 pip install -r requirements.txt --progress-bar off
 pip install sphinx sphinx_rtd_theme --progress-bar off


### PR DESCRIPTION
scikit-learn cannot be installed yet with python 3.9, this is making circle fail, see [comment](https://github.com/paris-saclay-cds/ramp-workflow/pull/257#issuecomment-734286148) in PR #257.