### PR TITLE
Autocompletion for submission names

### DIFF
--- a/doc/command_line.rst
+++ b/doc/command_line.rst
@@ -3,6 +3,13 @@
 RAMP-workflow commands
 ######################
 
+The following commands are built using the
+`click <https://click.palletsprojects.com/en/7.x/>`_ package which provides tab
+completion for the command options. You however need to activate shell
+completion by following the instructions given in the `click documentation <https://click.palletsprojects.com/en/7.x/bashcomplete/#activation>`_.
+The `ramp-test` command also comes with tab completion for the submission name
+if the submission you are looking for is located in the `./submissions/` folder.
+
 .. click:: rampwf.utils.cli.testing:main
     :prog: ramp-test
     :show-nested:

--- a/rampwf/utils/cli/testing.py
+++ b/rampwf/utils/cli/testing.py
@@ -9,11 +9,31 @@ from ..testing import assert_submission
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
+def get_submissions(ctx, args, incomplete):
+    """Call-back for submission autocomplete.
+
+    Find the possible submission names and use them for autocompletion.
+    This only works if the submissions can be found in a 'submissions' folder.
+    """
+    submission_dir_path = os.path.join('.', 'submissions')
+    try:
+        all_submissions = [
+            f.name for f in os.scandir(submission_dir_path)
+            if f.is_dir() and f.name != '__pycache__']
+    except FileNotFoundError:
+        return []
+    else:
+        valid_submissions = [submission for submission in all_submissions
+                             if incomplete in submission]
+        return valid_submissions
+
+
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--submission', default='starting_kit', show_default=True,
               help='The kit to test. It should be located in the '
               '"submissions" folder of the starting kit. If "ALL", all '
-              'submissions in the directory will be tested.')
+              'submissions in the directory will be tested.',
+              autocompletion=get_submissions)
 @click.option('--ramp-kit-dir', default='.', show_default=True,
               help='Root directory of the ramp-kit to test.')
 @click.option('--ramp-data-dir', default='.', show_default=True,

--- a/rampwf/utils/cli/testing.py
+++ b/rampwf/utils/cli/testing.py
@@ -10,10 +10,13 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 def get_submissions(ctx, args, incomplete):
-    """Call-back for submission autocomplete.
+    """Callback function for submission autocomplete.
 
     Find the possible submission names and use them for autocompletion.
     This only works if the submissions can be found in a 'submissions' folder.
+
+    See click documentation for more information on the signature of the
+    function.
     """
     submission_dir_path = os.path.join('.', 'submissions')
     try:

--- a/rampwf/utils/cli/tests/test_cli.py
+++ b/rampwf/utils/cli/tests/test_cli.py
@@ -16,8 +16,11 @@ def test_get_submissions(monkeypatch):
     monkeypatch.chdir(iris_kit_path)
 
     assert ['starting_kit'] == get_submissions(None, None, 'star')
-    submissions = get_submissions(None, None, '')
-    assert ['starting_kit', 'random_forest_10_10'] == submissions
+    completed_submissions = get_submissions(None, None, '')
+    true_submissions = ['starting_kit', 'random_forest_10_10']
+    # check ignoring order
+    assert len(completed_submissions) == len(true_submissions)
+    assert set(completed_submissions) == set(true_submissions)
 
 
 def test_bagged_table_and_headers():

--- a/rampwf/utils/cli/tests/test_cli.py
+++ b/rampwf/utils/cli/tests/test_cli.py
@@ -3,10 +3,21 @@ import os
 import pandas as pd
 import numpy as np
 
+from rampwf.utils.cli.testing import get_submissions
 from rampwf.utils.cli.show import _bagged_table_and_headers
 from rampwf.utils.cli.show import _mean_table_and_headers
 from rampwf.utils.cli.show import _load_score_submission
 PATH = os.path.dirname(__file__)
+
+
+def test_get_submissions(monkeypatch):
+    iris_kit_path = os.path.join(
+        PATH, '..', '..', '..', 'tests', 'kits', 'iris')
+    monkeypatch.chdir(iris_kit_path)
+
+    assert ['starting_kit'] == get_submissions(None, None, 'star')
+    submissions = get_submissions(None, None, '')
+    assert ['starting_kit', 'random_forest_10_10'] == submissions
 
 
 def test_bagged_table_and_headers():


### PR DESCRIPTION
If this can be useful to anyone I am sharing this here.

This was done following [click documentation](https://click.palletsprojects.com/en/7.x/bashcomplete/#shell-completion).

As written in the [documentation](https://click.palletsprojects.com/en/7.x/bashcomplete/#activation) I need to activate the autocompletion for my shell for this to work.