### PR TITLE
MAINT/Fix security vulnerability warning by updating to tensorflow 2.0.4

### DIFF
--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -9,6 +9,5 @@ netCDF4
 xarray
 scikit-image
 joblib
-keras<2.4; python_version >= '3.5' or (python_version == '2.7' and sys_platform != 'win32')
-tensorflow == 2.0.1; python_version >= '3.5' or (python_version == '2.7' and sys_platform != 'win32')
-
+keras<2.4
+tensorflow == 2.0.4


### PR DESCRIPTION
Fixes Github security warnings on the home page (and in email reminders). Tensorflow can probably be updated to a later version as well but I'm not fully sure about the implications and for now I just want to remove the warnings.