### PR TITLE
MAINT Add pre-commit, simplify flake8 setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+    -   id: flake8
+        types: [file, python]

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
     - pip install -r testing-requirements.txt
     - pip install .
 script:
-    - flake8 rampwf --ignore=F401,E211,E265,W503,W504 --exclude rampwf/externals
+    - flake8 rampwf
     - pytest -s -v --cov=rampwf rampwf
 after_success:
     - codecov

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-all:
 test: test-all
 
 code-analysis:
-	flake8 . --ignore=E501,E211,E265 | grep -v __init__ | grep -v external
+	flake8 .
 
 upload-pypi:
 	python setup.py sdist bdist_wheel && twine upload dist/*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,7 @@ import sphinx_rtd_theme
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('sphinxext'))
-from github_link import make_linkcode_resolve
+from github_link import make_linkcode_resolve  # noqa
 
 # -- General configuration ------------------------------------------------
 
@@ -45,8 +45,8 @@ extensions = [
 numpydoc_show_class_members = False
 
 # pngmath / imgmath compatibility layer for different sphinx versions
-import sphinx
-from distutils.version import LooseVersion
+import sphinx  # noqa
+from distutils.version import LooseVersion  # noqa
 if LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
     extensions.append('sphinx.ext.pngmath')
 else:
@@ -81,7 +81,7 @@ copyright = '2015 - 2019, Paris-Saclay Center for Data Science'
 # built documents.
 #
 # The short X.Y version.
-from rampwf import __version__
+from rampwf import __version__  # noqa
 version = __version__
 # The full version, including alpha/beta/rc tags.
 release = __version__

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -47,6 +47,17 @@ environment for ramp-workflow.
 
 .. _ramp-workflow: https://github.com/paris-saclay-cds/ramp-workflow
 
+Code style
+----------
+
+This repo uses `flake8` for code style. It can be run on commits automatically
+by installing and activating `pre-commit <https://pre-commit.com/>`_:
+
+.. code-block:: bash
+
+   pip install pre-commit
+   pre-commit install
+
 Release process
 ---------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore = F401,E211,E265,W503,W504
+exclude = .git,__pycache__,build,dist,rampwf/externals,doc/_templates


### PR DESCRIPTION
- Simplify flake8 usage by putting all relevant config in a `setup.cfg` file
- add a documentation section on code style under contributing
- add a minimal [pre-commit](https://pre-commit.com/) to make it more  convenient to run linters before each commit (use is optional) 