### PR TITLE
CLI Fix --ramp-submission-dir parameter in ramp-test

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,6 +22,8 @@ Changed
   (`#273 <https://github.com/paris-saclay-cds/ramp-workflow/pull/273>`_)
 - Fixes leaderboard (including fix for ``--bagged`` and ``--data-label`` options)
   (`#273 <https://github.com/paris-saclay-cds/ramp-workflow/pull/273>`_)
+- Fixes ``ramp-test`` when both ``--submission ALL`` and a ``--ramp-submission-dir`` are provided
+  (`#274 <https://github.com/paris-saclay-cds/ramp-workflow/pull/274>`_)
 
 
 Removed

--- a/rampwf/utils/cli/testing.py
+++ b/rampwf/utils/cli/testing.py
@@ -84,11 +84,11 @@ def main(submission, ramp_kit_dir, ramp_data_dir, data_label,
         warnings.simplefilter("ignore")
 
     if submission == "ALL":
-        ramp_submission_dir = os.path.join(ramp_kit_dir, 'submissions')
+        submissions_dir = os.path.join(ramp_kit_dir, ramp_submission_dir)
         submission = [
             directory
-            for directory in os.listdir(ramp_submission_dir)
-            if os.path.isdir(os.path.join(ramp_submission_dir, directory))
+            for directory in os.listdir(submissions_dir)
+            if os.path.isdir(os.path.join(submissions_dir, directory))
         ]
     else:
         submission = [submission]


### PR DESCRIPTION
A last small fix from advanced (https://github.com/paris-saclay-cds/ramp-workflow/pull/246) which correctly takes into account the `--ramp-submission-dir` parameter in ramp-test when `--submission=ALL`