### PR TITLE
ENH add the external_imports directory to sys.path

### DIFF
--- a/doc/problem.rst
+++ b/doc/problem.rst
@@ -310,5 +310,17 @@ file. It is worth taking a look at the `whole file
    The ``_read_data()`` is not strictly required and is acting as a helper
    function in the code above.
 
+8. If the ``problem.py`` file becomes too long and you would like to refactor
+   it, you can add an ``external_imports`` folder in the ``ramp_kit_dir`` and
+   have modules there that you can import from. The way this works is that
+   running ``ramp-test`` adds the ``external_imports`` folder to ``sys.path``
+   if such a folder exists. For instance if you have a ``utils.py`` module
+   in the ``external_imports`` folder::
+
+        external_imports/
+            utils.py
+
+   Then you can do ``import utils`` in ``problem.py``.
+
 .. _RAMP workflow: https://github.com/paris-saclay-cds/ramp-workflow
 .. _Pollenating insects: <https://github.com/ramp-kits/pollenating_insects>`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,7 +15,7 @@ Added
 - Added decoupled Cross Validation (`#271 <https://github.com/paris-saclay-cds/ramp-workflow/pull/271>`_)
 - Adds an option to ramp-blend to select the ``--score_metrics_index`` to blend on
   (`#273 <https://github.com/paris-saclay-cds/ramp-workflow/pull/273>`_)
-- Adds the possibility to import modules located inside the external_imports directory
+- Adds the possibility to import modules located inside the ``external_imports`` directory
   (`#181 <https://github.com/paris-saclay-cds/ramp-workflow/pull/279>`_)
 
 Changed

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,7 +16,7 @@ Added
 - Adds an option to ramp-blend to select the ``--score_metrics_index`` to blend on
   (`#273 <https://github.com/paris-saclay-cds/ramp-workflow/pull/273>`_)
 - Adds the possibility to import modules located inside the ``external_imports`` directory
-  (`#181 <https://github.com/paris-saclay-cds/ramp-workflow/pull/279>`_)
+  (`#279 <https://github.com/paris-saclay-cds/ramp-workflow/pull/279>`_)
 
 Changed
 -------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,8 @@ Added
 - Added decoupled Cross Validation (`#271 <https://github.com/paris-saclay-cds/ramp-workflow/pull/271>`_)
 - Adds an option to ramp-blend to select the ``--score_metrics_index`` to blend on
   (`#273 <https://github.com/paris-saclay-cds/ramp-workflow/pull/273>`_)
+- Adds the possibility to import modules located inside the external_imports directory
+  (`#181 <https://github.com/paris-saclay-cds/ramp-workflow/pull/279>`_)
 
 Changed
 -------

--- a/rampwf/tests/test_kits.py
+++ b/rampwf/tests/test_kits.py
@@ -35,10 +35,39 @@ def _generate_grid_path_kits():
     return grid
 
 
+def test_external_imports(tmpdir):
+    path_kit = tmpdir.join("titanic_external_imports")
+    shutil.copytree(os.path.join(PATH, "kits", "titanic"), path_kit)
+    problem_path = os.path.join(path_kit, "problem.py")
+    submissions_dir = os.path.join(path_kit, 'submissions')
+    submission_path = os.path.join(submissions_dir, 'starting_kit')
+    estimator_path = os.path.join(submission_path, "estimator.py")
+    for path in [problem_path, estimator_path]:
+        with open(path, 'r+') as f:
+            content = f.read()
+            f.seek(0, 0)
+            line1 = "from utils import test_imports as test"
+            line2 = "assert test.x == 2"
+            f.write(line1 + '\n' + line2 + '\n' + content)
+    utils_path = path_kit.mkdir("external_imports").mkdir("utils")
+    with open(os.path.join(utils_path, "test_imports.py"), 'w+') as f:
+        content = f.read()
+        f.seek(0, 0)
+        line = "x = 2"
+        f.write(line + '\n' + content)
+    assert_submission(
+        ramp_kit_dir=path_kit,
+        ramp_data_dir=path_kit,
+        ramp_submission_dir=submissions_dir,
+        submission=submission_path,
+        is_pickle=True,
+        save_output=False,
+        retrain=True)
+
+
 @pytest.mark.parametrize(
     "path_kit",
-    _generate_grid_path_kits()
-)
+    _generate_grid_path_kits())
 def test_notebook_testing(path_kit):
     # check if there is a notebook to be tested
     if len(glob.glob(os.path.join(path_kit, '*.ipynb'))):

--- a/rampwf/tests/test_kits.py
+++ b/rampwf/tests/test_kits.py
@@ -1,6 +1,7 @@
 import os
 import glob
 import shutil
+from textwrap import dedent
 
 import cloudpickle
 
@@ -36,25 +37,39 @@ def _generate_grid_path_kits():
 
 
 def test_external_imports(tmpdir):
+    # checking imports from an external_imports folder located in the
+    # ramp_kit_dir
+
+    # temporary kit
     path_kit = tmpdir.join("titanic_external_imports")
     shutil.copytree(os.path.join(PATH, "kits", "titanic"), path_kit)
     problem_path = os.path.join(path_kit, "problem.py")
     submissions_dir = os.path.join(path_kit, 'submissions')
     submission_path = os.path.join(submissions_dir, 'starting_kit')
     estimator_path = os.path.join(submission_path, "estimator.py")
+
+    # module to be imported
+    ext_module_dir = path_kit.mkdir("external_imports").mkdir("utils")
+    with open(os.path.join(ext_module_dir, "test_imports.py"), 'w+') as f:
+        f.write(
+            dedent(
+                """
+                x = 2
+                """
+            )
+        )
+
     for path in [problem_path, estimator_path]:
-        with open(path, 'r+') as f:
-            content = f.read()
-            f.seek(0, 0)
-            line1 = "from utils import test_imports as test"
-            line2 = "assert test.x == 2"
-            f.write(line1 + '\n' + line2 + '\n' + content)
-    utils_path = path_kit.mkdir("external_imports").mkdir("utils")
-    with open(os.path.join(utils_path, "test_imports.py"), 'w+') as f:
-        content = f.read()
-        f.seek(0, 0)
-        line = "x = 2"
-        f.write(line + '\n' + content)
+        with open(path, 'a') as f:
+            f.write(
+                dedent(
+                    """
+                    from utils import test_imports
+                    assert test_imports.x == 2
+                    """
+                )
+            )
+
     assert_submission(
         ramp_kit_dir=path_kit,
         ramp_data_dir=path_kit,

--- a/rampwf/utils/testing.py
+++ b/rampwf/utils/testing.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import os
 import shutil
+import sys
 
 import numpy as np
 import pandas as pd
@@ -26,6 +27,10 @@ def assert_notebook(ramp_kit_dir='.'):
 
 
 def assert_read_problem(ramp_kit_dir='.'):
+    # allowing external imports from the external_imports folder if it exists
+    ext_imp_dir = os.path.join(ramp_kit_dir, "external_imports")
+    if os.path.exists(ext_imp_dir) and ext_imp_dir not in sys.path:
+        sys.path.append(ext_imp_dir)
     # giving a random name to the module so it passes looped tests
     return import_module_from_source(
         os.path.join(ramp_kit_dir, 'problem.py'), 'problem'


### PR DESCRIPTION
Closes #181

With this PR merged, users would be able to import packages copied to external_imports directory.
This PR adds the external_imports directory to sys.path.

Let's imagine this kit structure:

problem.py
data/
external_imports/
......utils/
............test_imports.py

Then to import test_imports.py, it is sufficient to do (from inside problem.py or estimator/classifier.py):
from utils import test_imports 