### PR TITLE
Force sphinx to have version lower than 4.0

### DIFF
--- a/ci_tools/circle/build_doc.sh
+++ b/ci_tools/circle/build_doc.sh
@@ -13,7 +13,7 @@ conda update --yes --quiet conda
 conda create --name testenv python=3.8
 source activate testenv
 pip install -r requirements.txt --progress-bar off
-pip install sphinx sphinx_rtd_theme --progress-bar off
+pip install "sphinx<4.0" sphinx_rtd_theme --progress-bar off
 pip install sphinx-gallery sphinx-click
 pip install numpydoc
 pip install .


### PR DESCRIPTION
Fixing circle CI by using sphinx with a version lower than 4.0
Closes #278 