### PR TITLE
Fix LGTM.com error: Wrong number of arguments in a call

### DIFF
--- a/rampwf/score_types/detection/util.py
+++ b/rampwf/score_types/detection/util.py
@@ -211,7 +211,7 @@ def mask_detection_curve(y_true, y_pred, conf_thresholds):
 
     for conf_threshold in conf_thresholds:
         y_pred_above_confidence = _filter_y_pred(y_pred, conf_threshold)
-        ms.append(scp_single(y_true, y_pred_above_confidence))
+        ms.append(scp_single(y_true, y_pred_above_confidence, None))
 
     return np.array(ms)
 


### PR DESCRIPTION
* Fix the actual error. Whether some arguments should be made optional (with a default value of `None`) can be left for later.
* Clearly `rampwf.score_types.detection.util.mask_detection_curve` is not covered by tests.

Fixes #291.