### PR TITLE
Fix typos (repeated words)

### DIFF
--- a/rampwf/hyperopt/hyperopt.py
+++ b/rampwf/hyperopt/hyperopt.py
@@ -250,7 +250,7 @@ def parse_hyperparameters(module_path, workflow_element_name):
 def parse_all_hyperparameters(module_path, workflow):
     """Parse hyperparameters in a submission.
 
-    Load all the the modules, take all Hyperparameter objects, and set the name
+    Load all the modules, take all Hyperparameter objects, and set the name
     of each to the name of the hyperparameter the user chose and the workflow
     element name of each to the corresponding workflow_element_name.
 

--- a/rampwf/score_types/brier_score.py
+++ b/rampwf/score_types/brier_score.py
@@ -15,7 +15,7 @@ class BrierScore(BaseScoreType):
     def score_function(self, ground_truths, predictions):
         """A hybrid score.
 
-        It tests the the predicted _probability_ of the second class
+        It tests the predicted _probability_ of the second class
         against the true _label index_ (which is 0 if the first label is the
         ground truth, and 1 if it is not, in other words, it is the
         true probability of the second class). Thus we have to override the
@@ -42,7 +42,7 @@ class BrierSkillScore(BaseScoreType):
     def score_function(self, ground_truths, predictions):
         """A hybrid score.
 
-        It tests the the predicted _probability_ of the second class
+        It tests the predicted _probability_ of the second class
         against the true _label index_ (which is 0 if the first label is the
         ground truth, and 1 if it is not, in other words, it is the
         true probability of the second class). Thus we have to override the
@@ -77,7 +77,7 @@ class BrierScoreReliability(BaseScoreType):
     def score_function(self, ground_truths, predictions):
         """A hybrid score.
 
-        It tests the the predicted _probability_ of the second class
+        It tests the predicted _probability_ of the second class
         against the true _label index_ (which is 0 if the first label is the
         ground truth, and 1 if it is not, in other words, it is the
         true probability of the second class). Thus we have to override the
@@ -122,7 +122,7 @@ class BrierScoreResolution(BaseScoreType):
     def score_function(self, ground_truths, predictions):
         """A hybrid score.
 
-        It tests the the predicted _probability_ of the second class
+        It tests the predicted _probability_ of the second class
         against the true _label index_ (which is 0 if the first label is the
         ground truth, and 1 if it is not, in other words, it is the
         true probability of the second class). Thus we have to override the

--- a/rampwf/score_types/roc_auc.py
+++ b/rampwf/score_types/roc_auc.py
@@ -14,7 +14,7 @@ class ROCAUC(BaseScoreType):
     def score_function(self, ground_truths, predictions):
         """A hybrid score.
 
-        It tests the the predicted _probability_ of the second class
+        It tests the predicted _probability_ of the second class
         against the true _label index_ (which is 0 if the first label is the
         ground truth, and 1 if it is not, in other words, it is the
         true probability of the second class). Thus we have to override the

--- a/rampwf/tests/kits/digits/submissions/starting_kit/batch_classifier.py
+++ b/rampwf/tests/kits/digits/submissions/starting_kit/batch_classifier.py
@@ -49,7 +49,7 @@ class BatchClassifier(object):
             # is set to some number > 1, the neural net will be trained with
             # repetitions of the same data, because the workers are independent
             # and they got through the same generator.
-            # Hence it is necessary to introduce a shared lock between the the
+            # Hence it is necessary to introduce a shared lock between the
             # processes so that they load different data, this can become a bit
             # complicated, so I choose to rather load exactly one chunk at a
             # time using 1 worker (so `workers` have to be equal to 1), but

--- a/rampwf/workflows/clusterer.py
+++ b/rampwf/workflows/clusterer.py
@@ -14,7 +14,7 @@ receives only the coavariates and the event_id (assumed to be the first column
 of `X_array`). It slices up `X_array` into single events, drops the event ids,
 and sends the single event to the `predict_single_event` function implemented
 by the users. This function returns a vector of labels (cluster assignments)
-which is then joined back the the event id column and returned (to be passed
+which is then joined back to the event id column and returned (to be passed
 into `prediction_types.Clustering` and evaluated by
 `score_types.clustering_efficiency`).
 """


### PR DESCRIPTION
Not sure about `joined back the the` → `joined back to the` here:
> This function returns a vector of labels (cluster assignments) which is then joined back the the event id column and returned (to be passed into `prediction_types.Clustering` and evaluated by `score_types.clustering_efficiency`).