### PR TITLE
ENH allow open in user code for non-os moudles

### DIFF
--- a/rampwf/utils/sanitize.py
+++ b/rampwf/utils/sanitize.py
@@ -3,16 +3,28 @@ Utility for basic sanitation of user provided Python scripts.
 False negatives are expected.
 """
 import sys
+import re
 
-BLACKLIST = [
+BLACKLIST = {
     # subprocess module
-    'subprocess', 'Popen',
+    'subprocess': 'subprocess',
+    'Popen': 'Popen',
     # shutil module
-    'shutil', 'rmtree', 'copytree',
+    'shutil': 'shutil',
+    'rmtree': 'rmtree',
+    'copytree': 'copytree',
     # os module
-    'fdopen', 'fchmod', 'fchown', 'ftruncate', 'open', 'listdir', 'scandir',
-    'removedirs'
-]
+    'fdopen': 'fdopen',
+    'fchmod': 'fchmod',
+    'fchown': 'fchown',
+    'ftruncate': 'ftruncate',
+    'listdir': 'listdir',
+    'scandir': 'scandir',
+    'removedirs': 'removedirs',
+    # os.open or open keyword. Do not match all open as some challenge requires
+    # opening Images for instance with PIL with Image.open.
+    'open': '(?:os.| )open',
+}
 
 
 def _sanitize_input(code):
@@ -22,9 +34,9 @@ def _sanitize_input(code):
     warning / detections of users trying to tamper with the RAMP board system.
     """
 
-    for key in BLACKLIST:
-        if key in code:
-            msg = "forbidden key word {} detected in submission.".format(key)
+    for kw, pattern in BLACKLIST.items():
+        if len(re.findall(pattern, code)) > 0:
+            msg = f"forbidden key word {kw} detected in submission."
             if 'ramp_database' in sys.modules:
                 msg += (
                     ' Tampering with the RAMP server is strictly forbidden! '

--- a/rampwf/utils/tests/test_sanitize.py
+++ b/rampwf/utils/tests/test_sanitize.py
@@ -10,6 +10,12 @@ def test_sanitize_input():
     with pytest.raises(RuntimeError, match=msg):
         _sanitize_input("with open('test.txt', 'wr') as fh")
 
+    with pytest.raises(RuntimeError, match=msg):
+        _sanitize_input("f = os.open('test.txt', 'wr')")
+
+    # Make sure this does not catch open functions from other libraries:
+    _sanitize_input("im = Image.open('im001.jpg')")
+
     msg = "forbidden key word scandir detected"
     with pytest.raises(RuntimeError, match=msg):
         _sanitize_input("for _ in os.scandir()")


### PR DESCRIPTION
For some challenges, users need to load images with Image.open
from the PIL library. This is not possible as _sanitize_input
is too restrictive. This commits intend to change this.