### PR TITLE
Release version 0.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,14 +1,14 @@
 [bumpversion]
-current_version = 0.5.0.dev0
+current_version = 0.5.0
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}.{release}{dev}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = gamma
-values = 
+values =
 	dev
 	gamma
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.0.0/>`_
 and this project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 
-0.5.0 [Unreleased]
+0.5.0 - 2022-04-04
 ==================
 
 Added

--- a/rampwf/_version.py
+++ b/rampwf/_version.py
@@ -21,4 +21,4 @@
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 
-__version__ = '0.5.0.dev0'
+__version__ = '0.5.0'


### PR DESCRIPTION
Closes https://github.com/paris-saclay-cds/ramp-workflow/issues/300

I can confirm that this version will work with ramp-board CI.